### PR TITLE
Preserve blank line after tags

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -127,6 +127,9 @@ export class Formatter {
             if (isEmpty(line)) {
                 if (this.currentSection.name === "tags" && this.previousSection.name !== "widget") {
                     Object.assign(this.currentSection, this.previousSection);
+                    if (this.shouldInsertBlankLineAfterTags()) {
+                        this.insertBlankLineAfter()
+                    }
                     this.decreaseIndent();
                 }
                 continue;
@@ -156,6 +159,15 @@ export class Formatter {
         this.handleEndLines();
 
         return this.formattedText.join("\n");
+    }
+
+    /**
+     * Determines if blank line after tags should be inserted
+     */
+    private shouldInsertBlankLineAfterTags(): boolean {
+        const nextLine = this.lines[this.currentLine + 1];
+        /** Next line is not empty OR undefined */
+        return nextLine && !this.isSectionDeclaration(nextLine)
     }
 
     /**
@@ -225,6 +237,20 @@ export class Formatter {
      */
     private handleEndLines(): void {
         this.formattedText.push(...new Array(this.blankLinesAtEnd).fill(""));
+    }
+
+    /**
+     * Inserts blank line after current line
+     */
+    private insertBlankLineAfter(): void {
+        this.formattedText.push("");
+    }
+
+    /**
+     * Inserts blank line before current line
+     */
+    private insertBlankLineBefore(): void {
+        this.formattedText.splice(this.formattedText.length - 1, 0, "");
     }
 
     /**
@@ -377,7 +403,7 @@ export class Formatter {
             return;
         }
 
-        this.formattedText.splice(this.formattedText.length - 1, 0, "");
+        this.insertBlankLineBefore();
     }
 
     /**

--- a/src/test/indents.test.ts
+++ b/src/test/indents.test.ts
@@ -353,6 +353,7 @@ suite("Formatting indents tests: sections and settings", () => {
 
       [tags]
         startime = 2018
+
 starttime = 2018
 
 `;
@@ -363,7 +364,8 @@ starttime = 2018
 
       [tags]
         startime = 2018
-        starttime = 2018
+
+      starttime = 2018
 
 `;
     const formatter = new Formatter(FORMATTING_OPTIONS);


### PR DESCRIPTION
Closes #24 
First blank line after `[tags]` section should be preserved. Settings in `[tags]` after blank line are indented at parent level.
 
## Demo:
![tags-blank-lines](https://user-images.githubusercontent.com/15448200/63588617-9e761c00-c5af-11e9-9686-57c6fae613e9.gif)

## Explanation:
- Formatter cannot determine itself between what settings in `[tags]` blank line should be inserted, however we can just keep first blank line occurrence.
- If after `[tags]` section goes not parent-level setting but normal section declaration, no need to keep blank line — it would be inserted before section declaration next step.