### PR TITLE
Handle [column] settings

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -125,9 +125,9 @@ export class Formatter {
         this.lines = text.split("\n");
         for (let line = this.getLine(this.currentLine); line !== void 0; line = this.nextLine()) {
             if (isEmpty(line)) {
-                if (this.currentSection.name === "tags" && this.previousSection.name !== "widget") {
+                if (this.insideSectionException()) {
                     Object.assign(this.currentSection, this.previousSection);
-                    if (this.shouldInsertBlankLineAfterTags()) {
+                    if (this.shouldInsertBlankLineInsideSection()) {
                         this.insertBlankLineAfter()
                     }
                     this.decreaseIndent();
@@ -162,9 +162,18 @@ export class Formatter {
     }
 
     /**
-     * Determines if blank line after tags should be inserted
+     * We are inside tags/column section
+     * They may contain empty line between their own and parent-level settings
      */
-    private shouldInsertBlankLineAfterTags(): boolean {
+    private insideSectionException(): boolean {
+        return (this.currentSection.name === "tags" && this.previousSection.name !== "widget")
+        || this.currentSection.name === "column";
+    }
+
+    /**
+     * Determines if blank line after tags/column should be inserted
+     */
+    private shouldInsertBlankLineInsideSection(): boolean {
         const nextLine = this.lines[this.currentLine + 1];
         /** Next line is not empty OR undefined */
         return nextLine && !this.isSectionDeclaration(nextLine)

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -81,3 +81,9 @@ export const CALCULATED_REGEXP: RegExp = /[@$]\{.+\}/;
 
 // =, ==, !=, >=, <=, >, <
 export const RELATIONS_REGEXP: RegExp = new RegExp(`(^\\s*.+?)(\\s*?)(${RELATIONS.join("|")})(\\s*)`);
+
+// tag(s)|key(s)|column — sections, whose settings are handled in different way
+export const SECTIONS_EXCEPTIONS_REGEXP: RegExp = /(?:tag|key)s?|column/;
+
+// tag|column
+export const TAG_OR_COLUMN_REGEXP: RegExp = /tag|column/;

--- a/src/test/columnSections.test.ts
+++ b/src/test/columnSections.test.ts
@@ -1,0 +1,51 @@
+import assert = require("assert");
+import { Validator } from "../validator";
+import { createDiagnostic, createRange } from "../util";
+
+const baseConfig = (setting: string) => `[configuration]
+[group]
+    [widget]
+        type = chart
+        [column]
+
+        ${setting}
+        [series]
+            metric = a
+            entity = b`;
+
+suite("[column] section tests", () => {
+    test("Correct: 'sort' gives no warning", () => {
+        const config = baseConfig(`sort = command
+        `);
+        const validator = new Validator(config);
+        const actual = validator.lineByLine();
+        const expected = [];
+        assert.deepStrictEqual(actual, expected, `Config: \n${config}`);
+    });
+
+    test("Correct: 'columns' gives no warning", () => {
+        const config = baseConfig(`columns = a, b
+        `);
+        const validator = new Validator(config);
+        const actual = validator.lineByLine();
+        const expected = [];
+        assert.deepStrictEqual(actual, expected, `Config: \n${config}`);
+    });
+
+    test("Incorrect: duplicate 'columns' setting", () => {
+        const config = baseConfig(`columns = a, b
+        columns = c, d
+        `);
+        const validator = new Validator(config);
+        const actual = validator.lineByLine();
+        const expected = [
+            createDiagnostic(
+                createRange(
+                    8, "columns".length, 7
+                ),
+                "columns is already defined"
+            )
+        ];
+        assert.deepStrictEqual(actual, expected, `Config: \n${config}`);
+    });
+});

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -33,7 +33,8 @@ import {
     getSetting,
     isAnyInArray,
     isInMap,
-    repetitionDiagnostic
+    repetitionDiagnostic,
+    isEmpty
 } from "./util";
 
 const placeholderContainingSettings = [
@@ -561,7 +562,7 @@ export class Validator {
             /**
              * We are in [tags] section and current line is empty - [tags] section has finished
              */
-            (line.trim().length === 0 && this.currentSection !== undefined && this.currentSection.text === "tags")) {
+            (isEmpty(line) && this.currentSection  && this.currentSection.text === "tags")) {
             // We met start of the next section, that means that current section has finished
             if (this.match !== null) {
                 this.spellingCheck();

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -425,9 +425,9 @@ export class Validator {
         if (this.currentSection === undefined) {
             return;
         }
-        if (this.previousSection && /tag/i.test(this.currentSection.text)) {
+        if (this.previousSection && /tag|column/i.test(this.currentSection.text)) {
             /**
-             * [tags] has finished, perform checks for parent section.
+             * [tags] or [column] has finished, perform checks for parent section.
              */
             this.currentSettings = this.previousSettings;
             this.currentSection = this.previousSection;
@@ -562,7 +562,7 @@ export class Validator {
             /**
              * We are in [tags] section and current line is empty - [tags] section has finished
              */
-            (isEmpty(line) && this.currentSection  && this.currentSection.text === "tags")) {
+            (isEmpty(line) && this.currentSection && /tags|column/.test(this.currentSection.text))) {
             // We met start of the next section, that means that current section has finished
             if (this.match !== null) {
                 this.spellingCheck();
@@ -826,8 +826,8 @@ export class Validator {
             return;
         }
         const [, indent, name] = this.match;
-        const nextIsTags = this.currentSection && /tag/i.test(name);
-        if (!nextIsTags) {
+        const nextIsTagsOrColumn = this.currentSection && /tag|column/i.test(name);
+        if (!nextIsTagsOrColumn) {
             /**
              * If the next is [tags], no need to perform checks for current section now,
              * they will be done after [tags] section finished.
@@ -883,10 +883,10 @@ export class Validator {
             return;
         }
         const line: string = this.config.getCurrentLine();
-        if (this.currentSection === undefined || !/(?:tag|key)s?/.test(this.currentSection.text)) {
+        if (this.currentSection === undefined || !/(?:tag|key)s?|column/.test(this.currentSection.text)) {
             this.handleRegularSetting();
-        } else if (/(?:tag|key)s?/.test(this.currentSection.text) &&
-            // We are in tags/keys section
+        } else if (/(?:tag|key)s?|column/.test(this.currentSection.text) &&
+            // We are in tags/keys/column section
             /(^[ \t]*)([a-z].*?[a-z])[ \t]*=/.test(line)) {
             this.match = /(^[ \t]*)([a-z].*?[a-z])[ \t]*=/.exec(line);
             if (this.match === null) {
@@ -945,7 +945,7 @@ export class Validator {
     }
 
     /**
-     * Processes a regular setting which is defined not in tags/keys section
+     * Processes a regular setting which is defined not in tags/keys/column section
      */
     private handleRegularSetting(): void {
         const line: string = this.config.getCurrentLine();


### PR DESCRIPTION
Settings of `[column]` section separated with empty line and indented at parent level refer to parent section. Same as `[tags]`

* `columns` setting: https://apps.axibase.com/chartlab/97d3ca47/36#
* `sort` setting: https://apps.axibase.com/chartlab/d7c8ed94/3/