### PR TITLE
Fix if condition

### DIFF
--- a/src/keywordHandler.ts
+++ b/src/keywordHandler.ts
@@ -11,6 +11,7 @@ import {
     EXPR_END,
     EXPR_START,
     EXPR_START_WITHOUT_LF,
+    IF_CONDITION_REGEX,
     ONE_LINE_SCRIPT,
     ONE_LINE_SQL
 } from "./regExpressions";
@@ -74,8 +75,7 @@ export class KeywordHandler {
      */
     public handleIf(): void {
         const line = this.config.getCurrentLine();
-        const ifConditionRegex: RegExp = /^[\s].*if\s*(.*)/;
-        const ifCondition = ifConditionRegex.exec(line)[1];
+        const ifCondition = IF_CONDITION_REGEX.exec(line)[1];
 
         if (ifCondition.trim() === "") {
             this.diagnostics.push(

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -99,3 +99,6 @@ export const ONE_LINE_COMMENT: RegExp = /\/\*([\s\S]*?)(?=\*\/)/;
 
 // number of spaces until first non-space character -  "   hello" // 3
 export const SPACES_AT_START: RegExp = /[^ ]/;
+
+// extract if condition — if a == 2 // condition:  a == 2
+export const IF_CONDITION_REGEX: RegExp = /^[\s]*if\s*(.*)/;

--- a/src/test/ifCondition.test.ts
+++ b/src/test/ifCondition.test.ts
@@ -84,4 +84,19 @@ suite("If condition syntax tests", () => {
         );
         deepStrictEqual(actualDiagnostics, [expectedDiagnostic], `Config: \n${config}`);
     });
+
+    test("Correct if condition with no space before `if`", () => {
+        const config = `[configuration]
+        [group]
+          [widget]
+            type = chart
+            [series]
+              entity = a
+              metric = b
+if true
+              endif`;
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        deepStrictEqual(actualDiagnostics, [], `Config: \n${config}`);
+    });
 });


### PR DESCRIPTION
Closes #53 

Handling if condition was OK, however regex wasn't concise enough — it didn't work if there was no space before `if`. Fixed it.

`^[\s].*if\s*(.*)` -> `^[\s]*if\s*(.*)`