### PR TITLE
Calendar validation rules

### DIFF
--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -73,6 +73,9 @@ export const INTERVAL_REGEXP: RegExp = new RegExp(
     `^(?:(?:[-+]?(?:(?:\\d+|(?:\\d+)?\\.\\d+)|@\\{.+\\})[ \\t]*(?:${INTERVAL_UNITS.join("|")}))|all)$`,
 );
 
+// 1 hour, 2 week
+export const TIME_UNIT_REGEXP: RegExp = /(\d+)\s+(\w+)/i;
+
 // 1, 5.2, 0.3, .9, -8, -0.5, +1.4
 export const NUMBER_REGEXP: RegExp = /^(?:\-|\+)?(?:\.\d+|\d+(?:\.\d+)?)$/;
 

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -74,7 +74,7 @@ export const INTERVAL_REGEXP: RegExp = new RegExp(
 );
 
 // 1 hour, 2 week
-export const TIME_UNIT_REGEXP: RegExp = /([1-9]\d*)(?:\s*\*\s*|\s+)([_a-z]+)/i;
+export const TIME_UNIT_REGEXP: RegExp = /([1-9]\d*)(?:\s+)([_a-z]+)/i;
 
 // 1, 5.2, 0.3, .9, -8, -0.5, +1.4
 export const NUMBER_REGEXP: RegExp = /^(?:\-|\+)?(?:\.\d+|\d+(?:\.\d+)?)$/;

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -74,7 +74,7 @@ export const INTERVAL_REGEXP: RegExp = new RegExp(
 );
 
 // 1 hour, 2 week
-export const TIME_UNIT_REGEXP: RegExp = /(\d+)\s+(\w+)/i;
+export const TIME_UNIT_REGEXP: RegExp = /([1-9]\d*)(?:\s*\*\s*|\s+)([_a-z]+)/i;
 
 // 1, 5.2, 0.3, .9, -8, -0.5, +1.4
 export const NUMBER_REGEXP: RegExp = /^(?:\-|\+)?(?:\.\d+|\d+(?:\.\d+)?)$/;

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -73,8 +73,8 @@ export const INTERVAL_REGEXP: RegExp = new RegExp(
     `^(?:(?:[-+]?(?:(?:\\d+|(?:\\d+)?\\.\\d+)|@\\{.+\\})[ \\t]*(?:${INTERVAL_UNITS.join("|")}))|all)$`,
 );
 
-// 1 hour, 2 week
-export const TIME_UNIT_REGEXP: RegExp = /([1-9]\d*)(?:\s+)([_a-z]+)/i;
+// 0.5 hour, 2 week
+export const COUNT_UNIT_FORMAT = /(\d+(?:\.\d+)?)\s+(\w+)/;
 
 // 1, 5.2, 0.3, .9, -8, -0.5, +1.4
 export const NUMBER_REGEXP: RegExp = /^(?:\-|\+)?(?:\.\d+|\d+(?:\.\d+)?)$/;

--- a/src/relatedSettingsRules/index.ts
+++ b/src/relatedSettingsRules/index.ts
@@ -3,6 +3,7 @@ import { noUselessSettingsForSeries, noUselessSettingsForWidget } from "./presen
 import simultaneousTimeSettings from "./presenceValidation/noUselessSettings/simultaneousTimeSettings";
 import requiredSettings from "./presenceValidation/requiredSettings";
 import { Rule } from "./utils/interfaces";
+import calendarPaletteTicks from "./valueValidation/calendarPaletteTicks";
 import calendarTimespan from "./valueValidation/calendarTimespan";
 import colorsThresholds from "./valueValidation/colorsThresholds";
 import forecastAutoCountAndEigentripleLimit from "./valueValidation/forecastAutoCountAndEigentripleLimit";
@@ -29,6 +30,7 @@ const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
     ],
     [
         "widget", [
+            calendarPaletteTicks,
             calendarTimespan,
             noUselessSettingsForWidget,
             simultaneousTimeSettings,

--- a/src/relatedSettingsRules/index.ts
+++ b/src/relatedSettingsRules/index.ts
@@ -10,6 +10,7 @@ import forecastSsaGroupAutoUnion from "./valueValidation/forecastSsaGroupAutoUni
 import forecastSsaGroupManualGroups from "./valueValidation/forecastSsaGroupManualGroups";
 import forecastStartTime from "./valueValidation/forecastStartTime";
 import startEndTime from "./valueValidation/startEndTime";
+import summarizePeriodTimespan from "./valueValidation/summarizePeriodTimespan";
 
 const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
     [
@@ -29,7 +30,8 @@ const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
         "widget", [
             noUselessSettingsForWidget,
             simultaneousTimeSettings,
-            startEndTime
+            startEndTime,
+            summarizePeriodTimespan
         ]
     ]
 ]);

--- a/src/relatedSettingsRules/index.ts
+++ b/src/relatedSettingsRules/index.ts
@@ -3,6 +3,7 @@ import { noUselessSettingsForSeries, noUselessSettingsForWidget } from "./presen
 import simultaneousTimeSettings from "./presenceValidation/noUselessSettings/simultaneousTimeSettings";
 import requiredSettings from "./presenceValidation/requiredSettings";
 import { Rule } from "./utils/interfaces";
+import calendarTimespan from "./valueValidation/calendarTimespan";
 import colorsThresholds from "./valueValidation/colorsThresholds";
 import forecastAutoCountAndEigentripleLimit from "./valueValidation/forecastAutoCountAndEigentripleLimit";
 import forecastEndTime from "./valueValidation/forecastEndTime";
@@ -28,6 +29,7 @@ const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
     ],
     [
         "widget", [
+            calendarTimespan,
             noUselessSettingsForWidget,
             simultaneousTimeSettings,
             startEndTime,

--- a/src/relatedSettingsRules/valueValidation/calendarPaletteTicks.ts
+++ b/src/relatedSettingsRules/valueValidation/calendarPaletteTicks.ts
@@ -36,7 +36,7 @@ const rule: Rule = {
         if (noTicks) {
             return createDiagnostic(
                 ticks.textRange,
-                `For multiple series with no 'range-merge' and no 'thresholds' specified ticks won't show`,
+                `Palette ticks will not be displayed if the widget contains multiple series with individual ranges. Enable 'range-merge' or set common 'thresholds' to display ticks.`,
                 DiagnosticSeverity.Warning
             );
         }

--- a/src/relatedSettingsRules/valueValidation/calendarPaletteTicks.ts
+++ b/src/relatedSettingsRules/valueValidation/calendarPaletteTicks.ts
@@ -1,0 +1,46 @@
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
+import { Section } from "../../configTree/section";
+import { Setting } from "../../setting";
+import { createDiagnostic, getValueOfSetting } from "../../util";
+import { requiredCondition } from "../utils/condition";
+import { Rule } from "../utils/interfaces";
+
+const rule: Rule = {
+    name: "calendar pallete-ticks display condition",
+    check(section: Section): Diagnostic | void {
+
+        if (!section.matchesConditions([
+            requiredCondition("type", ["calendar"])
+        ])) {
+            return;
+        }
+
+        const ticks: Setting = section.getSettingFromTree("palette-ticks");
+
+        if (ticks === undefined) {
+            return;
+        }
+
+        /**
+         * Calendar has > 2 series
+         */
+        const multipleSeries: boolean = section.children.filter(
+            child => child.name === "series"
+        ).length > 1;
+
+        const noThresholds: boolean = section.getSettingFromTree("thresholds") === undefined;
+        const noRangeMerge: boolean = getValueOfSetting("range-merge", section) !== "true";
+
+        const noTicks: boolean = multipleSeries && noThresholds && noRangeMerge;
+
+        if (noTicks) {
+            return createDiagnostic(
+                ticks.textRange,
+                `For multiple series with no 'range-merge' and no 'thresholds' specified ticks won't show`,
+                DiagnosticSeverity.Warning
+            );
+        }
+    }
+};
+
+export default rule;

--- a/src/relatedSettingsRules/valueValidation/calendarPaletteTicks.ts
+++ b/src/relatedSettingsRules/valueValidation/calendarPaletteTicks.ts
@@ -36,7 +36,8 @@ const rule: Rule = {
         if (noTicks) {
             return createDiagnostic(
                 ticks.textRange,
-                `Palette ticks will not be displayed if the widget contains multiple series with individual ranges. Enable 'range-merge' or set common 'thresholds' to display ticks.`,
+                "Palette ticks will not be displayed if the widget contains multiple series with individual ranges. " +
+                "Enable 'range-merge' or set common 'thresholds' to display ticks.",
                 DiagnosticSeverity.Warning
             );
         }

--- a/src/relatedSettingsRules/valueValidation/calendarTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/calendarTimespan.ts
@@ -1,0 +1,34 @@
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
+import { Section } from "../../configTree/section";
+import { Setting } from "../../setting";
+import { createDiagnostic } from "../../util";
+import { requiredCondition } from "../utils/condition";
+import { Rule } from "../utils/interfaces";
+
+const rule: Rule = {
+    name: "calendar requires a definitive timespan (all is not allowed)",
+    check(section: Section): Diagnostic | void {
+
+        if (!section.matchesConditions([
+            requiredCondition("type", ["calendar"])
+        ])) {
+            return;
+        }
+
+        const timespan: Setting = section.getSettingFromTree("timespan");
+
+        if (timespan === undefined) {
+            return;
+        }
+
+        if (timespan.value === "all") {
+            return createDiagnostic(
+                timespan.textRange,
+                `calendar requires a definitive timespan (all is not allowed)`,
+                DiagnosticSeverity.Error
+            );
+        }
+    }
+};
+
+export default rule;

--- a/src/relatedSettingsRules/valueValidation/calendarTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/calendarTimespan.ts
@@ -24,7 +24,7 @@ const rule: Rule = {
         if (timespan.value === "all") {
             return createDiagnostic(
                 timespan.textRange,
-                `calendar requires a definitive timespan (all is not allowed)`,
+                `Timespan 'all' is not supported by the calendar widget`,
                 DiagnosticSeverity.Error
             );
         }

--- a/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
@@ -38,7 +38,7 @@ const rule: Rule = {
         if (summarizePeriodDate.getTime() > timespanDate.getTime()) {
             return createDiagnostic(
                 summarizePeriod.textRange,
-                `For calendar summarize-period should not be greater than timespan`,
+                `The 'summarize-period' must be less than the selection interval.`,
                 DiagnosticSeverity.Warning
             );
         }

--- a/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
@@ -1,0 +1,39 @@
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
+import { Section } from "../../configTree/section";
+import { Setting } from "../../setting";
+import { parseTimeValue } from "../../time";
+import { createDiagnostic } from "../../util";
+import { requiredCondition } from "../utils/condition";
+import { Rule } from "../utils/interfaces";
+
+const rule: Rule = {
+    name: "summarize-period should not be greater than timespan",
+    check(section: Section): Diagnostic | void {
+
+        if (!section.matchesConditions([
+            requiredCondition("type", ["calendar"])
+        ])) {
+            return;
+        }
+
+        const summarizePeriod: Setting = section.getSettingFromTree("summarize-period");
+        const timespan: Setting = section.getSettingFromTree("timespan");
+
+        if (summarizePeriod === undefined || timespan === undefined) {
+            return;
+        }
+
+        const summarizePeriodDate = parseTimeValue(summarizePeriod, section, []);
+        const timespanDate = parseTimeValue(timespan, section, []);
+
+        if (summarizePeriodDate.getTime() > timespanDate.getTime()) {
+            return createDiagnostic(
+                summarizePeriod.textRange,
+                `For calendar summarize-period should not be greater than timespan`,
+                DiagnosticSeverity.Warning
+            );
+        }
+    }
+};
+
+export default rule;

--- a/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
@@ -23,8 +23,17 @@ const rule: Rule = {
             return;
         }
 
-        const summarizePeriodDate = parseTimeValue(summarizePeriod, section, []);
-        const timespanDate = parseTimeValue(timespan, section, []);
+        /**
+         * Errors when parsing calendar time values
+         */
+        const errors: Diagnostic[] = [];
+
+        const summarizePeriodDate = parseTimeValue(summarizePeriod, section, errors);
+        const timespanDate = parseTimeValue(timespan, section, errors);
+
+        if (errors.length) {
+            return errors[0];
+        }
 
         if (summarizePeriodDate.getTime() > timespanDate.getTime()) {
             return createDiagnostic(

--- a/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
@@ -1,7 +1,7 @@
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 import { Section } from "../../configTree/section";
 import { Setting } from "../../setting";
-import { parseTimeValue } from "../../time";
+import { IntervalParser } from "../../time/intervalParser";
 import { createDiagnostic } from "../../util";
 import { requiredCondition } from "../utils/condition";
 import { Rule } from "../utils/interfaces";
@@ -23,19 +23,14 @@ const rule: Rule = {
             return;
         }
 
-        /**
-         * Errors when parsing calendar time values
-         */
-        const errors: Diagnostic[] = [];
+        const summarizePeriodValue = IntervalParser.getValue(summarizePeriod.value);
+        const timespanValue = IntervalParser.getValue(timespan.value);
 
-        const summarizePeriodDate = parseTimeValue(summarizePeriod, section, errors);
-        const timespanDate = parseTimeValue(timespan, section, errors);
-
-        if (errors.length) {
-            return errors[0];
+        if (!summarizePeriodValue || !timespanValue) {
+            return;
         }
 
-        if (summarizePeriodDate.getTime() > timespanDate.getTime()) {
+        if (summarizePeriodValue > timespanValue) {
             return createDiagnostic(
                 summarizePeriod.textRange,
                 `The 'summarize-period' must be less than the selection interval.`,

--- a/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
+++ b/src/relatedSettingsRules/valueValidation/summarizePeriodTimespan.ts
@@ -1,7 +1,7 @@
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 import { Section } from "../../configTree/section";
 import { Setting } from "../../setting";
-import { IntervalParser } from "../../time/intervalParser";
+import { parseIntervalValue } from "../../time";
 import { createDiagnostic } from "../../util";
 import { requiredCondition } from "../utils/condition";
 import { Rule } from "../utils/interfaces";
@@ -19,12 +19,8 @@ const rule: Rule = {
         const summarizePeriod: Setting = section.getSettingFromTree("summarize-period");
         const timespan: Setting = section.getSettingFromTree("timespan");
 
-        if (summarizePeriod === undefined || timespan === undefined) {
-            return;
-        }
-
-        const summarizePeriodValue = IntervalParser.getValue(summarizePeriod.value);
-        const timespanValue = IntervalParser.getValue(timespan.value);
+        const summarizePeriodValue = parseIntervalValue(summarizePeriod);
+        const timespanValue = parseIntervalValue(timespan);
 
         if (!summarizePeriodValue || !timespanValue) {
             return;

--- a/src/test/calendarValidationRules.test.ts
+++ b/src/test/calendarValidationRules.test.ts
@@ -18,7 +18,7 @@ const baseConfig = (timespan: string, summarizePeriod: string) => `[configuratio
       entity = nurswgvml006
       metric = cpu_busy`;
 
-suite("Calendar validation rules", () => {
+suite("Calendar type specfifc validation rules", () => {
     test("Incorrect: summarize-period is greater than timespan", () => {
         const config = baseConfig("1 hour", "1 day");
         const validator = new Validator(config);
@@ -28,6 +28,20 @@ suite("Calendar validation rules", () => {
                 createRange(4, 16, 9),
                 `For calendar summarize-period should not be greater than timespan`,
                 DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostics, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Incorrect: calendar has timespan 'all'", () => {
+        const config = baseConfig("all", "1 day");
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 8, 8),
+                `calendar requires a definitive timespan (all is not allowed)`,
+                DiagnosticSeverity.Error
             )
         ];
         deepStrictEqual(actualDiagnostics, expectedDiagnostic, `Config: \n${config}`);

--- a/src/test/calendarValidationRules.test.ts
+++ b/src/test/calendarValidationRules.test.ts
@@ -35,7 +35,7 @@ suite("Calendar type specfifc validation rules", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 16, 5),
-                `For calendar summarize-period should not be greater than timespan`,
+                `The 'summarize-period' must be less than the selection interval.`,
                 DiagnosticSeverity.Warning
             )
         ];
@@ -49,7 +49,7 @@ suite("Calendar type specfifc validation rules", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 8, 4),
-                `calendar requires a definitive timespan (all is not allowed)`,
+                `Timespan 'all' is not supported by the calendar widget`,
                 DiagnosticSeverity.Error
             )
         ];
@@ -63,7 +63,8 @@ suite("Calendar type specfifc validation rules", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 13, 8),
-                `For multiple series with no 'range-merge' and no 'thresholds' specified ticks won't show`,
+                "Palette ticks will not be displayed if the widget contains multiple series with individual ranges. " +
+                "Enable 'range-merge' or set common 'thresholds' to display ticks.",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/calendarValidationRules.test.ts
+++ b/src/test/calendarValidationRules.test.ts
@@ -47,6 +47,35 @@ suite("Calendar type specfifc validation rules", () => {
         deepStrictEqual(actualDiagnostics, expectedDiagnostic, `Config: \n${config}`);
     });
 
+    test("Incorrect: no 'range-merge' or 'thresholds' specified", () => {
+        const config = `
+        [configuration]
+  metric = cpu_busy
+  entity = nurswgvml00*
+
+[group]
+
+  [widget]
+    type = calendar
+    title = palette-ticks = true
+    palette-ticks = true
+
+    [series]
+
+    [series]
+`;
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 13, 10),
+                `For multiple series with no 'range-merge' and no 'thresholds' specified ticks won't show`,
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostics, expectedDiagnostic, `Config: \n${config}`);
+    });
+
     test("Correct: summarize-period is equal to timespan", () => {
         const config = baseConfig("1 hour", "1 hour");
         const validator = new Validator(config);

--- a/src/test/summarizePeriodTimespan.test.ts
+++ b/src/test/summarizePeriodTimespan.test.ts
@@ -1,0 +1,43 @@
+import { deepStrictEqual } from "assert";
+import { DiagnosticSeverity } from "vscode-languageserver-types";
+import { createDiagnostic, createRange } from "../util";
+import { Validator } from "../validator";
+
+const baseConfig = (timespan: string, summarizePeriod: string) => `[configuration]
+  height-units = 2
+  width-units = 1
+
+[group]
+
+  [widget]
+    type = calendar
+    timespan = ${timespan}
+    summarize-period = ${summarizePeriod}
+
+    [series]
+      entity = nurswgvml006
+      metric = cpu_busy`;
+
+suite("Calendar validation rules", () => {
+    test("Incorrect: summarize-period is greater than timespan", () => {
+        const config = baseConfig("1 hour", "1 day");
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 16, 9),
+                `For calendar summarize-period should not be greater than timespan`,
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostics, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Correct: summarize-period is equal to timespan", () => {
+        const config = baseConfig("1 hour", "1 hour");
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostics, expectedDiagnostic, `Config: \n${config}`);
+    });
+});

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -4,10 +4,10 @@ import { dateError } from "../messageUtil";
 import { Setting } from "../setting";
 import { createDiagnostic, getValueOfSetting } from "../util";
 import { IntervalParser } from "./intervalParser";
-import { TimeParseError } from "./timeParseError";
 import { TimeParser } from "./timeParser";
 
 const timeParseCache: Map<Setting, Date> = new Map<Setting, Date>();
+
 /**
  * Parses value of time setting, adds diagnostic to `errors` if any error during parsing was thrown.
  *
@@ -32,13 +32,9 @@ export function parseTimeValue(timeSetting: Setting, section: Section, errors: D
             parsedValue = timeParser.parseDateTemplate(timeSetting.value);
             timeParseCache.set(timeSetting, parsedValue);
         } catch (err) {
-            if (err instanceof TimeParseError) {
-                const diagnostic = createDiagnostic(timeSetting.textRange,
+            const diagnostic = createDiagnostic(timeSetting.textRange,
                     dateError(err.message, timeSetting.displayName));
-                errors.push(diagnostic);
-            } else {
-                throw err;
-            }
+            errors.push(diagnostic);
         }
     }
     return parsedValue;
@@ -57,17 +53,13 @@ export function parseIntervalValue(intervalSetting: Setting/*, errors: Diagnosti
         try {
             parsedValue = IntervalParser.parse(intervalSetting.value);
         } catch (err) {
-            if (err instanceof TimeParseError) {
-                // Commented for now, because syntax is checked in Setting.checkType.
-                // It may be convenient to use this method instead of code in case "interval".
-                /*
-                const diagnostic = createDiagnostic(intervalSetting.textRange,
-                    intervalError(err.message, intervalSetting.displayName));
-                errors.push(diagnostic);
-                */
-            } else {
-                throw err;
-            }
+            // Commented for now, because syntax is checked in Setting.checkType.
+            // It may be convenient to use this method instead of code in case "interval".
+            /*
+             const diagnostic = createDiagnostic(intervalSetting.textRange,
+             intervalError(err.message, intervalSetting.displayName));
+             errors.push(diagnostic);
+             */
         }
     }
     return parsedValue;

--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -3,6 +3,7 @@ import { Section } from "../configTree/section";
 import { dateError } from "../messageUtil";
 import { Setting } from "../setting";
 import { createDiagnostic, getValueOfSetting } from "../util";
+import { IntervalParser } from "./intervalParser";
 import { TimeParseError } from "./timeParseError";
 import { TimeParser } from "./timeParser";
 
@@ -11,8 +12,8 @@ const timeParseCache: Map<Setting, Date> = new Map<Setting, Date>();
  * Parses value of time setting, adds diagnostic to `errors` if any error during parsing was thrown.
  *
  * @param timeSetting - Date setting, which value is need to be parsed
- * @param timeParser - Util class, containig methods for date parsing
- * @param errors - Array of diagnosics, to which information about error is added
+ * @param section - Section, for which "time-zone" setting is need to be found.
+ * @param errors - Array of diagnostics, to which information about error is added
  * @returns Value of `timeSetting`, parsed to Date.
  */
 export function parseTimeValue(timeSetting: Setting, section: Section, errors: Diagnostic[]): Date {
@@ -35,6 +36,35 @@ export function parseTimeValue(timeSetting: Setting, section: Section, errors: D
                 const diagnostic = createDiagnostic(timeSetting.textRange,
                     dateError(err.message, timeSetting.displayName));
                 errors.push(diagnostic);
+            } else {
+                throw err;
+            }
+        }
+    }
+    return parsedValue;
+}
+
+/**
+ * Parses value of interval setting, adds diagnostic to `errors` if any error during parsing was thrown.
+ *
+ * @param intervalSetting - Interval setting, which value is need to be parsed
+ * @param errors - Array of diagnostics, to which information about error is added
+ * @returns Value of `intervalSetting`, parsed to number.
+ */
+export function parseIntervalValue(intervalSetting: Setting/*, errors: Diagnostic[]*/): number {
+    let parsedValue;
+    if (intervalSetting != null) {
+        try {
+            parsedValue = IntervalParser.parse(intervalSetting.value);
+        } catch (err) {
+            if (err instanceof TimeParseError) {
+                // Commented for now, because syntax is checked in Setting.checkType.
+                // It may be convenient to use this method instead of code in case "interval".
+                /*
+                const diagnostic = createDiagnostic(intervalSetting.textRange,
+                    intervalError(err.message, intervalSetting.displayName));
+                errors.push(diagnostic);
+                */
             } else {
                 throw err;
             }

--- a/src/time/intervalParser.ts
+++ b/src/time/intervalParser.ts
@@ -34,7 +34,7 @@ export class IntervalParser {
 
         value = milliseconds * parseFloat(count);
 
-        if (isFinite(value) === false) {
+        if (!isFinite(value)) {
             throw new Error(`Can't parse interval «${interval}»`);
         }
 

--- a/src/time/intervalParser.ts
+++ b/src/time/intervalParser.ts
@@ -24,7 +24,7 @@ export class IntervalParser {
         const [, count, unit] = match;
 
         /**
-         * How many milliseconds includes time unit
+         * Amount of milliseconds per time-unit
          */
         const milliseconds = this.timeUnits.get(unit);
 

--- a/src/time/intervalParser.ts
+++ b/src/time/intervalParser.ts
@@ -34,7 +34,7 @@ export class IntervalParser {
 
         value = milliseconds * parseFloat(count);
 
-        if (isNaN(value) || !isFinite(value)) {
+        if (isFinite(value) === false) {
             throw new Error(`Can't parse interval «${interval}»`);
         }
 

--- a/src/time/intervalParser.ts
+++ b/src/time/intervalParser.ts
@@ -1,0 +1,43 @@
+import { TIME_UNIT_REGEXP } from "../regExpressions";
+
+export class IntervalParser {
+    public static timeUnits: Map<string, number> = new Map([
+        ["sec", 1000],
+        ["second", 1000],
+        ["min", 60000],
+        ["minute", 60000],
+        ["hour", 3600000],
+        ["day", 86400000],
+        ["week", 604800000],
+        ["month", 2592000000],
+        ["year", 31536000000],
+    ]);
+
+    public static getValue(interval: string): number {
+        const match = TIME_UNIT_REGEXP.exec(interval);
+        let value: number;
+
+        if (match === null) {
+            return;
+        }
+
+        const [, count, unit] = match;
+
+        /**
+         * How many milliseconds includes time unit
+         */
+        const milliseconds = this.timeUnits.get(unit);
+
+        if (milliseconds === undefined) {
+            throw new Error(`Unsupported time units ${unit}`);
+        }
+
+        value = milliseconds * parseFloat(count);
+
+        if (isNaN(value) || !isFinite(value)) {
+            throw new Error(`Can't parse interval «${interval}»`);
+        }
+
+        return value;
+    }
+}

--- a/src/time/timeParseError.ts
+++ b/src/time/timeParseError.ts
@@ -1,5 +1,4 @@
 export class TimeParseError extends Error {
-    public wrongValue: string;
     public message: string;
 
     /**
@@ -10,7 +9,6 @@ export class TimeParseError extends Error {
     constructor(wrongValue: string, message: string) {
         super(message);
         this.message = message + ": " + wrongValue;
-        this.wrongValue = wrongValue;
         this.name = this.constructor.name;
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, this.constructor);

--- a/src/time/timeParser.ts
+++ b/src/time/timeParser.ts
@@ -1,3 +1,4 @@
+import { IntervalParser } from "./intervalParser";
 import { TimeParseError } from "./timeParseError";
 import {
     DateFunction,
@@ -23,33 +24,6 @@ export class TimeParser {
         }],
         ["date", () => {
             return new Date();
-        }],
-        ["sec", () => {
-            return 1000;
-        }],
-        ["second", () => {
-            return 1000;
-        }],
-        ["min", () => {
-            return 60000;
-        }],
-        ["minute", () => {
-            return 60000;
-        }],
-        ["hour", () => {
-            return 3600000;
-        }],
-        ["day", () => {
-            return 86400000;
-        }],
-        ["week", () => {
-            return 604800000;
-        }],
-        ["month", () => {
-            return 2592000000;
-        }],
-        ["year", () => {
-            return 31536000000;
         }],
         ["current_minute", (d: Date) => {
             return getCurrentMinute(d, this.isUTC);
@@ -212,43 +186,11 @@ export class TimeParser {
         while (m) {
             let count;
             let unit;
-            let currentSign = m[1] === "-" ? -sign : sign;
+            const currentSign = m[1] === "-" ? -sign : sign;
             count = currentSign * +m[2];
             unit = m[3].toLowerCase();
-
-            switch (unit) {
-                case "year":
-                    baseTime.setFullYear(baseTime.getFullYear() + count);
-                    break;
-                case "quarter":
-                    baseTime.setMonth(baseTime.getMonth() + 3 * count);
-                    break;
-                case "month":
-                    baseTime.setMonth(baseTime.getMonth() + count);
-                    break;
-                case "week":
-                    baseTime.setTime(baseTime.getTime() + count * 604800000);
-                    break;
-                case "day":
-                    baseTime.setTime(baseTime.getTime() + count * 86400000);
-                    break;
-                case "hour":
-                    baseTime.setTime(baseTime.getTime() + count * 3600000);
-                    break;
-                case "min": /* alias to 'minute' */
-                case "minute":
-                    baseTime.setTime(baseTime.getTime() + count * 60000);
-                    break;
-                case "sec": /* alias to 'second' */
-                case "second":
-                    baseTime.setTime(baseTime.getTime() + count * 1000);
-                    break;
-                case "millisecond":
-                    baseTime.setTime(baseTime.getTime() + count);
-                    break;
-                default:
-                    throw new TimeParseError(unit, "Incorrect interval unit");
-            }
+            const intervalAsMillis = IntervalParser.getIntervalAsMillis(count, unit);
+            baseTime.setTime(baseTime.getTime() + intervalAsMillis);
             m = PARSE_SPAN_SYNTAX.exec(timespan);
         }
 

--- a/src/time/timeParser.ts
+++ b/src/time/timeParser.ts
@@ -7,7 +7,6 @@ import {
     shiftHour,
     shiftMinute
 } from "./utils";
-import { INTERVAL_REGEXP } from "../regExpressions";
 
 export class TimeParser {
     /**
@@ -175,12 +174,6 @@ export class TimeParser {
         const d = this.parseIsoLikeTemplate(v, now);
         if (d != null) {
             return d;
-        }
-        /**
-         * hack: allow to parse interval keywords alone, such as 1 hour
-         */
-        if (INTERVAL_REGEXP.exec(v)) {
-            v = `now + ${v}`;
         }
         // start-time = current_day + 9 hour + 50 minute
         const baseAndSpan = v.split(/([+\-])/);

--- a/src/time/timeParser.ts
+++ b/src/time/timeParser.ts
@@ -169,7 +169,7 @@ export class TimeParser {
      * @returns Date object, corresponding to `settingValue` template.
      */
     public parseDateTemplate(settingValue: string): Date {
-        let v: string = settingValue.trim();
+        const v: string = settingValue.trim();
         const now = Date.now();
         const d = this.parseIsoLikeTemplate(v, now);
         if (d != null) {

--- a/src/time/timeParser.ts
+++ b/src/time/timeParser.ts
@@ -7,6 +7,7 @@ import {
     shiftHour,
     shiftMinute
 } from "./utils";
+import { INTERVAL_REGEXP } from "../regExpressions";
 
 export class TimeParser {
     /**
@@ -169,11 +170,17 @@ export class TimeParser {
      * @returns Date object, corresponding to `settingValue` template.
      */
     public parseDateTemplate(settingValue: string): Date {
-        const v: string = settingValue.trim();
+        let v: string = settingValue.trim();
         const now = Date.now();
         const d = this.parseIsoLikeTemplate(v, now);
         if (d != null) {
             return d;
+        }
+        /**
+         * hack: allow to parse interval keywords alone, such as 1 hour
+         */
+        if (INTERVAL_REGEXP.exec(v)) {
+            v = `now + ${v}`;
         }
         // start-time = current_day + 9 hour + 50 minute
         const baseAndSpan = v.split(/([+\-])/);


### PR DESCRIPTION
1) `summarize-period` must be less than `timespan` 

2) Don't allow `timespan = 'all'` in calendar

3) Added `palette-ticks` validation rule. They won't be shown if we have multiple series with no `range-merge` or `thresholds` specified.
