### PR TITLE
Forecast baseline settings validation

### DIFF
--- a/src/relatedSettingsRules/presenceValidation/requiredSettings.ts
+++ b/src/relatedSettingsRules/presenceValidation/requiredSettings.ts
@@ -125,6 +125,13 @@ const checks: Map<string, Requirement> = new Map<string, Requirement>([
                 requiredCondition("type", ["console"])
             ],
             requiredSetting: "collapsible"
+        }],
+    [
+        "forecast-baseline-function", {
+            conditions: [
+                requiredCondition("type", ["chart"])
+            ],
+            requiredSetting: ["forecast-baseline-count", "forecast-baseline-period"]
         }]
 ]);
 

--- a/src/resources/descriptions.md
+++ b/src/resources/descriptions.md
@@ -498,6 +498,18 @@ Integration parameter `d`, a number of `0` or `1`.
   
 Auto-regression parameter `p`.  
   
+## forecastbaselinecount  
+  
+Number of previous windows, excluding the last window, used in baseline calculation.  
+  
+## forecastbaselinefunction  
+  
+Statistical function used to filter values when calculating baseline.  
+  
+## forecastbaselineperiod  
+  
+The distance between the previous windows used in baseline calculation.  
+  
 ## forecasthorizoninterval  
   
 Generate a forecast for the specified interval into the future starting with last sample of the loaded series.

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -2298,6 +2298,44 @@
             ]
         },
         {
+            "displayName": "forecast-baseline-count",
+            "type": "integer",
+            "example": "3",
+            "minValue": 0,
+            "section": "series",
+            "widget": "chart",
+            "excludes": [
+                "forecast-baseline-period"
+            ]
+        },
+        {
+            "displayName": "forecast-baseline-function",
+            "type": "enum",
+            "example": "avg",
+            "section": "series",
+            "widget": "chart",
+            "enum": [
+                "count",
+                "min",
+                "max",
+                "sum",
+                "avg",
+                "percentile\\((\\d{1,2}(\\.\\d)?|100)\\)",
+                "median",
+                "standard_deviation"
+            ]
+        },
+        {
+            "displayName": "forecast-baseline-period",
+            "type": "interval",
+            "example": "1 week",
+            "section": "series",
+            "widget": "chart",
+            "excludes": [
+                "forecast-baseline-count"
+            ]
+        },
+        {
             "displayName": "forecast-horizon-interval",
             "type": "interval",
             "example": "3 day",

--- a/src/test/forecast.test.ts
+++ b/src/test/forecast.test.ts
@@ -1,6 +1,6 @@
 import assert = require("assert");
 import { DiagnosticSeverity, Position, Range } from "vscode-languageserver-types";
-import { createDiagnostic, createRange } from "../util";
+import { createDiagnostic } from "../util";
 import { Validator } from "../validator";
 
 const config = `[configuration]

--- a/src/test/forecast.test.ts
+++ b/src/test/forecast.test.ts
@@ -344,35 +344,4 @@ forecast-horizon-start-time = now - 2*day`;
         let diags = validator.lineByLine();
         assert.deepStrictEqual(diags, [], `Config: \n${conf}`);
     });
-
-    test("Incorrect: both forecast-baseline-count and forecast-baseline-period (exclusive) are declared", () => {
-        const conf = `${config}
-forecast-baseline-function = avg
-forecast-baseline-count = 2
-forecast-baseline-period = 1 hour`;
-        let validator = new Validator(conf);
-        let diags = validator.lineByLine();
-        let expected = [
-            createDiagnostic(
-                createRange(0, 24, 9),
-                "forecast-baseline-period can not be specified simultaneously with forecast-baseline-count"
-            )
-        ];
-        assert.deepStrictEqual(diags, expected, `Config: \n${conf}`);
-    });
-
-    test("Incorrect: both forecast-baseline-count and forecast-baseline-period are missing", () => {
-        const conf = `${config}
-forecast-baseline-function = avg`;
-        let validator = new Validator(conf);
-        let diags = validator.lineByLine();
-        let expected = [
-            createDiagnostic(
-                createRange(1, 6, 6),
-                "forecast-baseline-function has effect only with one of the following:\n" +
-                " * forecast-baseline-count\n * forecast-baseline-period"
-            )
-        ];
-        assert.deepStrictEqual(diags, expected, `Config: \n${conf}`);
-    });
 });


### PR DESCRIPTION
Added forecast-baseline settings validation rules:

- `forecast-baseline-count` and `forecast-baseline-period` are exclusive

- exactly one of `forecast-baseline-count` and `forecast-baseline-period` is required if `forecast-baseline-function` is specified

There are no descriptions yet, because settings aren't documented at the moment