### PR TITLE
Fix indent increment in multiline comments

### DIFF
--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -101,7 +101,7 @@ export const BLOCK_COMMENT_END: RegExp = /(.*)(\*\/)(.*)$/;
 export const ONE_LINE_COMMENT: RegExp = /\/\*([\s\S]*?)(?=\*\/)/;
 
 // number of spaces until first non-space character -  "   hello" // 3
-export const SPACES_AT_START: RegExp = /[^ ]/;
+export const SPACES_AT_START: RegExp = /[^\s+]/;
 
 // matches 1+ consequent spaces not surrounded by quotes
 export const UNQUOTED_CONSEQUENT_SPACES: RegExp = /((['"])(?:\\.|[^\2])*?\2)|(\s\s+)/;

--- a/src/test/comentsFormating.test.ts
+++ b/src/test/comentsFormating.test.ts
@@ -160,4 +160,24 @@ height-units = 4
     const actual = formatter.format(text);
     deepStrictEqual(actual, expected);
   });
+
+  test("Multiline comment indents don't become bigger on reformatting", () => {
+    const text = `[configuration]
+  type = chart
+  title = Click on me
+  /*
+    Open dialog widget only on confirm.
+  */
+
+`;
+    const expected = text;
+    const formatter = new Formatter();
+    /**
+     * We intentionally run formatter twice to make sure indents aren't increased
+     */
+    const actual = formatter.format(
+      formatter.format(text)
+    );
+    deepStrictEqual(actual, expected);
+  });
 });


### PR DESCRIPTION
Closes #78 

Now multiline comments indents aren't increased on reformatting ⤵️

![Sep-25-2019 17-07-12](https://user-images.githubusercontent.com/15448200/65608522-06f15800-dfb7-11e9-901f-b03d3385721b.gif)
