### PR TITLE
Disable 'columns' warning

### DIFF
--- a/src/test/columnSections.test.ts
+++ b/src/test/columnSections.test.ts
@@ -27,6 +27,18 @@ suite("[column] section tests", () => {
         assert.deepStrictEqual(actual, expected, `Config: \n${config}`);
     });
 
+    /**
+     * Here is a temporary warning supression. Now we cannot refer setting to parent section.
+     * Probably, this will be changed, when syntax tree is build.
+     */
+    test("Correct: no warning for 'columns' after [column]", () => {
+        const config = baseConfig(`columns = quantity, trade_num, order_num`);
+        const validator = new Validator(config);
+        const actual = validator.lineByLine();
+        const expected = [];
+        assert.deepStrictEqual(actual, expected, `Config: \n${config}`);
+    });
+
     test("[column] is not interpreted as [tags]", () => {
         const config = `[configuration]
       [group]

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -937,6 +937,12 @@ export class Validator {
         if (setting.section == null || this.currentSection == null) {
             return true;
         }
+        /**
+         * Temporary workaround: 'columns' defined after [column] shouldn't raise a warning
+         */
+        if (setting.displayName === "columns" && this.currentSection.text === "column") {
+            return true;
+        }
         const currDepth: number = ResourcesProviderBase.sectionDepthMap[this.currentSection.text];
         if (setting.name === "mode") {
             if (this.currentWidget == null) {


### PR DESCRIPTION
Now `columns` defined after `[column]` won't raise a warning.

![image](https://user-images.githubusercontent.com/15448200/65671751-79fadd00-e050-11e9-9899-d33a66d2c366.png)
