### PR TITLE
Validate [group] capacity

### DIFF
--- a/src/relatedSettingsRules/index.ts
+++ b/src/relatedSettingsRules/index.ts
@@ -13,6 +13,7 @@ import forecastStartTime from "./valueValidation/forecastStartTime";
 import paletteTicks from "./valueValidation/paletteTicks";
 import startEndTime from "./valueValidation/startEndTime";
 import summarizePeriodTimespan from "./valueValidation/summarizePeriodTimespan";
+import widgetsPerRow from "./valueValidation/widgetsPerRow";
 
 const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
     [
@@ -36,6 +37,11 @@ const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
             simultaneousTimeSettings,
             startEndTime,
             summarizePeriodTimespan
+        ]
+    ],
+    [
+        "group", [
+            widgetsPerRow
         ]
     ]
 ]);

--- a/src/relatedSettingsRules/valueValidation/widgetsPerRow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsPerRow.ts
@@ -1,0 +1,42 @@
+import { Diagnostic } from "vscode-languageserver-types";
+import { Section } from "../../configTree/section";
+import { createDiagnostic, getValueOfSetting } from "../../util";
+import { Rule } from "../utils/interfaces";
+
+const rule: Rule = {
+    name: "check that amount of widgets per row fits group capacity",
+    check(section: Section): Diagnostic | void {
+        let errorMessage: string;
+        const dimensions: string[] = ["width-units", "height-units"];
+
+        /**
+         * Compare width-units and height-units of child widgets with parent's dimensions
+         */
+        dimensions.forEach(dimension => {
+            const widgetsDimensions = section.children.reduce((total, childSection) => {
+                const value = getValueOfSetting(dimension, childSection, false) as string;
+                return total + parseFloat(value);
+            }, 0);
+
+            const groupDimensions = +getValueOfSetting(dimension, section.parent, false);
+
+            if (widgetsDimensions > groupDimensions) {
+                if (errorMessage) {
+                    errorMessage = `Widgets' ${dimensions.join(" and ")} don't fit group capacity`;
+                } else {
+                    errorMessage = `Widgets' ${dimension} doesn't fit group capacity`;
+                }
+            }
+
+        });
+
+        if (errorMessage) {
+            return createDiagnostic(
+                section.range.range,
+                errorMessage
+            );
+        }
+    }
+};
+
+export default rule;

--- a/src/relatedSettingsRules/valueValidation/widgetsPerRow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsPerRow.ts
@@ -1,10 +1,10 @@
-import { Diagnostic } from "vscode-languageserver-types";
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 import { Section } from "../../configTree/section";
 import { createDiagnostic, getValueOfSetting } from "../../util";
 import { Rule } from "../utils/interfaces";
 
 const rule: Rule = {
-    name: "check that amount of widgets per row fits group capacity",
+    name: "check that widgets per row don't overflow [group]",
     check(section: Section): Diagnostic | void {
         let errorMessage: string;
         /**
@@ -17,7 +17,7 @@ const rule: Rule = {
         }, 0);
 
         if (widgetsWidth > groupWidth) {
-            errorMessage = `Widgets' width-units doesn't fit group capacity`;
+            errorMessage = `Widgets overflow [group] horizontally. Decrease number of widgets per row`;
         }
 
         /**
@@ -31,16 +31,18 @@ const rule: Rule = {
 
         if (widgetsExceedHeight) {
             if (errorMessage) {
-                errorMessage = `Widgets' width-units and height-units don't fit group capacity`;
+                errorMessage = `Widgets overflow [group]\n`
+                    + `Decrease widget's height-units and number of widgets per row`;
             } else {
-                errorMessage = `Widgets' height-units doesn't fit group capacity`;
+                errorMessage = `Widgets overflow [group] vertically. Decrease widget's height-units`;
             }
         }
 
         if (errorMessage) {
             return createDiagnostic(
                 section.range.range,
-                errorMessage
+                errorMessage,
+                DiagnosticSeverity.Warning
             );
         }
     }

--- a/src/relatedSettingsRules/valueValidation/widgetsPerRow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsPerRow.ts
@@ -7,28 +7,35 @@ const rule: Rule = {
     name: "check that amount of widgets per row fits group capacity",
     check(section: Section): Diagnostic | void {
         let errorMessage: string;
-        const dimensions: string[] = ["width-units", "height-units"];
+        /**
+         * Compare summary width-units of child widgets with parent's dimensions
+         */
+        const groupWidth = +getValueOfSetting("width-units", section.parent, false);
+        const widgetsWidth = section.children.reduce((total, childSection) => {
+            const value = getValueOfSetting("width-units", childSection, false) as string;
+            return total + parseFloat(value);
+        }, 0);
+
+        if (widgetsWidth > groupWidth) {
+            errorMessage = `Widgets' width-units doesn't fit group capacity`;
+        }
 
         /**
-         * Compare width-units and height-units of child widgets with parent's dimensions
+         * Widgets are placed next to each other, so we need to check only single widget max-height
          */
-        dimensions.forEach(dimension => {
-            const widgetsDimensions = section.children.reduce((total, childSection) => {
-                const value = getValueOfSetting(dimension, childSection, false) as string;
-                return total + parseFloat(value);
-            }, 0);
-
-            const groupDimensions = +getValueOfSetting(dimension, section.parent, false);
-
-            if (widgetsDimensions > groupDimensions) {
-                if (errorMessage) {
-                    errorMessage = `Widgets' ${dimensions.join(" and ")} don't fit group capacity`;
-                } else {
-                    errorMessage = `Widgets' ${dimension} doesn't fit group capacity`;
-                }
-            }
-
+        const groupHeight = +getValueOfSetting("height-units", section.parent, false);
+        const widgetsExceedHeight = section.children.some(childSection => {
+            const value = getValueOfSetting("height-units", childSection, false) as string;
+            return parseFloat(value) > groupHeight;
         });
+
+        if (widgetsExceedHeight) {
+            if (errorMessage) {
+                errorMessage = `Widgets' width-units and height-units don't fit group capacity`;
+            } else {
+                errorMessage = `Widgets' height-units doesn't fit group capacity`;
+            }
+        }
 
         if (errorMessage) {
             return createDiagnostic(

--- a/src/resources/descriptions.md
+++ b/src/resources/descriptions.md
@@ -685,6 +685,10 @@ Specify the number of gradient colors between each color in Color Range.
 ## gradientintensity  
   
 Color intensity of the first and the last sector in each range.  
+    
+## griddisplay  
+  
+Show grid displaying how many widgets can be in group.  
   
 ## groupfirst  
   
@@ -1361,10 +1365,6 @@ Fatal: `7`.
 ## severitystyle  
   
 Control alert behavior. Highlight a single column or entire row.  
-  
-## showgrid  
-  
-Show grid displaying how many widgets can be in group.  
   
 ## showtagnames  
   

--- a/src/resources/descriptions.md
+++ b/src/resources/descriptions.md
@@ -685,7 +685,7 @@ Specify the number of gradient colors between each color in Color Range.
 ## gradientintensity  
   
 Color intensity of the first and the last sector in each range.  
-    
+  
 ## griddisplay  
   
 Show grid displaying how many widgets can be in group.  

--- a/src/resources/descriptions.md
+++ b/src/resources/descriptions.md
@@ -1362,6 +1362,10 @@ Fatal: `7`.
   
 Control alert behavior. Highlight a single column or entire row.  
   
+## showgrid  
+  
+Show grid displaying how many widgets can be in group.  
+  
 ## showtagnames  
   
 Display all entity tags.  

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -3082,7 +3082,15 @@
             "type": "number",
             "minValue": 0,
             "example": 2,
-            "section": "widget"
+            "section": "widget",
+            "override": {
+                "[section == 'configuration']": {
+                    "defaultValue": 4
+                },
+                "[section == 'widget']": {
+                    "defaultValue": 1
+                }
+            }
         },
         {
             "displayName": "hidden",
@@ -8887,7 +8895,15 @@
             "type": "number",
             "example": 2,
             "minValue": 0,
-            "section": "widget"
+            "section": "widget",
+            "override": {
+                "[section == 'configuration']": {
+                    "defaultValue": 6
+                },
+                "[section == 'widget']": {
+                    "defaultValue": 1
+                }
+            }
         },
         {
             "displayName": "zoom-svg",

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -3083,12 +3083,10 @@
             "minValue": 0,
             "example": 2,
             "section": "widget",
+            "defaultValue": 1,
             "override": {
                 "[section == 'configuration']": {
                     "defaultValue": 4
-                },
-                "[section == 'widget']": {
-                    "defaultValue": 1
                 }
             }
         },
@@ -8896,12 +8894,10 @@
             "example": 2,
             "minValue": 0,
             "section": "widget",
+            "defaultValue": 1,
             "override": {
                 "[section == 'configuration']": {
                     "defaultValue": 6
-                },
-                "[section == 'widget']": {
-                    "defaultValue": 1
                 }
             }
         },

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -2990,9 +2990,9 @@
         {
             "displayName": "grid-display",
             "type": "boolean",
-            "example": false,
+            "example": true,
             "section": "configuration",
-            "defaultValue": true
+            "defaultValue": false
         },
         {
             "displayName": "group",

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -2988,6 +2988,13 @@
             "widget": "gauge"
         },
         {
+            "displayName": "grid-display",
+            "type": "boolean",
+            "example": false,
+            "section": "configuration",
+            "defaultValue": true
+        },
+        {
             "displayName": "group",
             "section": "widget",
             "widget": "bar",
@@ -6784,13 +6791,6 @@
                 "row",
                 "column"
             ]
-        },
-        {
-            "displayName": "show-grid",
-            "type": "boolean",
-            "example": false,
-            "section": "configuration",
-            "defaultValue": true
         },
         {
             "displayName": "show-tag-names",

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -6786,6 +6786,13 @@
             ]
         },
         {
+            "displayName": "show-grid",
+            "type": "boolean",
+            "example": false,
+            "section": "configuration",
+            "defaultValue": true
+        },
+        {
             "displayName": "show-tag-names",
             "type": "boolean",
             "example": true,

--- a/src/test/widgetsPerRow.test.ts
+++ b/src/test/widgetsPerRow.test.ts
@@ -1,4 +1,5 @@
 import { deepStrictEqual } from "assert";
+import { DiagnosticSeverity } from "vscode-languageserver-types";
 import { createDiagnostic, createRange } from "../util";
 import { Validator } from "../validator";
 
@@ -35,7 +36,8 @@ suite("Widgets per row tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(1, 5, 3),
-                "Widgets' width-units doesn't fit group capacity"
+                "Widgets overflow [group] horizontally. Decrease number of widgets per row",
+                DiagnosticSeverity.Warning
             )
         ];
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
@@ -48,7 +50,8 @@ suite("Widgets per row tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(1, 5, 3),
-                "Widgets' height-units doesn't fit group capacity"
+                "Widgets overflow [group] vertically. Decrease widget's height-units",
+                DiagnosticSeverity.Warning
             )
         ];
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
@@ -73,7 +76,8 @@ suite("Widgets per row tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(1, 5, 3),
-                "Widgets' width-units and height-units don't fit group capacity"
+                "Widgets overflow [group]\nDecrease widget's height-units and number of widgets per row",
+                DiagnosticSeverity.Warning
             )
         ];
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);

--- a/src/test/widgetsPerRow.test.ts
+++ b/src/test/widgetsPerRow.test.ts
@@ -42,7 +42,7 @@ suite("Widgets per row tests", () => {
     });
 
     test("Incorrect: height-units exceed limit", () => {
-        const config = baseConfig("height-units = 30", "height-units = 2");
+        const config = baseConfig("height-units = 32", "height-units = 2");
         const validator = new Validator(config);
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
@@ -63,7 +63,7 @@ suite("Widgets per row tests", () => {
     });
 
     test("Incorrect: height and width units exceed limit", () => {
-        const config = baseConfig(`height-units = 30
+        const config = baseConfig(`height-units = 32
     width-units = 30`,
 `width-units = 30
     height-units = 30

--- a/src/test/widgetsPerRow.test.ts
+++ b/src/test/widgetsPerRow.test.ts
@@ -1,0 +1,89 @@
+import { deepStrictEqual } from "assert";
+import { createDiagnostic, createRange } from "../util";
+import { Validator } from "../validator";
+
+const baseConfig = (dim1: string, dim2: string = "") => `[configuration]
+width-units = 40
+height-units = 30
+[group]
+  [widget]
+    type = chart
+    ${dim1}
+    [series]
+      metric = a
+      entity = b
+  [widget]
+    type = chart
+    ${dim2}
+    [series]
+      metric = a
+      entity = b`;
+
+suite("Widgets per row tests", () => {
+    test("Correct: both dimensions are within limits", () => {
+        const config = baseConfig("width-units = 39");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Incorrect: width-units exceed limit", () => {
+        const config = baseConfig("height-units = 5", "width-units = 40");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(1, 5, 3),
+                "Widgets' width-units doesn't fit group capacity"
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Incorrect: height-units exceed limit", () => {
+        const config = baseConfig("height-units = 30", "height-units = 2");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(1, 5, 3),
+                "Widgets' height-units doesn't fit group capacity"
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Correct: default dimensions", () => {
+        const config = baseConfig("");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Incorrect: height and width units exceed limit", () => {
+        const config = baseConfig(`height-units = 30
+    width-units = 30`,
+`width-units = 30
+    height-units = 30
+        `);
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(1, 5, 3),
+                "Widgets' width-units and height-units don't fit group capacity"
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Correct: fractional dimensions within limits", () => {
+        const config = baseConfig("height-units = 1.5", "height-units = 28.5");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,7 @@
 import { Diagnostic, DiagnosticSeverity, Position, Range } from "vscode-languageserver-types";
 import { Section } from "./configTree/section";
-import { Setting } from "./setting";
 import { LanguageService } from "./languageService";
-import { DefaultSetting } from "./defaultSetting";
+import { Setting } from "./setting";
 
 const DIAGNOSTIC_SOURCE: string = "Axibase Charts";
 
@@ -211,7 +210,7 @@ export function getValueOfSetting(
 ): string | number | boolean {
     let value: string | number | boolean;
     let setting = recursive ? section.getSettingFromTree(settingName) : section.getSetting(
-        DefaultSetting.clearSetting(settingName)
+        Setting.clearSetting(settingName)
     );
     if (setting === undefined) {
         /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -222,7 +222,7 @@ export function getValueOfSetting(
             /**
              * Apply section-dependent defaultValue overrides
              */
-            const widget: Setting = section.getSetting("type");
+            const widget: Setting = section.getSettingFromTree("type");
             setting = setting.applyScope({
                 section: section.name,
                 widget: widget ? widget.value : "",


### PR DESCRIPTION
Summary widget dimensions (`width-` and `height-units`) mustn't exceed `[group]` capacity (`width-` and `height-units` set in `[configuration]`)

**For instance:**
1. OK — total widgets' dimensions are within group limits
```
[configuration]
  width-units = 4
  height-units = 2
[group]
  [widget]
    width-units = 2
    height-units = 1
    ...
  [widget]
    width-units = 2
    height-units = 1
    ...
```
2. NOT OK — widgets contents will overflow group container
```
[configuration]
  width-units = 4
  height-units = 2
[group]
  [widget]
    width-units = 2
    height-units = 1
    ...
  [widget]
    width-units = 2
    height-units = 1
    ...
  [widget]
    width-units = 2
    height-units = 1
    ...
```
