### PR TITLE
Alter "position" setting usage

### DIFF
--- a/src/resources/descriptions.md
+++ b/src/resources/descriptions.md
@@ -224,6 +224,10 @@ Redefine default palette.
 Table, Console, Property, Text, and Page widgets do not support this setting.  
 Default palette is defined by the array `window.defaultColors`.  
   
+## columnorder  
+  
+Position of the column relative to other columns in the table.  
+  
 ## contextheight  
   
 Define the height of the context graph. Used to adjust the displayed timespan.  
@@ -1221,7 +1225,7 @@ Define the location of the final value pointer.
   
 ## position  
   
-Position of the column relative to other columns in the table.  
+Specifies cells on the grid where widget will be located.  
   
 ## primarykey  
   

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -820,6 +820,12 @@
             "section": "widget"
         },
         {
+            "displayName": "column-order",
+            "section": "column",
+            "type": "string",
+            "example": "first"
+        },
+        {
             "displayName": "columns",
             "type": "string",
             "example": "pid, command",
@@ -5589,9 +5595,9 @@
         },
         {
             "displayName": "position",
-            "section": "column",
+            "section": "widget",
             "type": "string",
-            "example": "first"
+            "example": "1-1, 2-2"
         },
         {
             "displayName": "primary-key",


### PR DESCRIPTION
Now "position" setting will be used to locate widgets on the grid.

Renamed old "position" -> "column-order"