### PR TITLE
Absolutely positioned widgets validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 lib
 types
+.idea

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -136,4 +136,4 @@ export const VAR_OPEN_BRACKET: RegExp = /(=)?\s*[\[\{\(](|.*,)\s*$/;
 export const VAR_CLOSE_BRACKET: RegExp = /\s*[\]\}\)]\s*/;
 
 // position = 1-1, 2-2
-export const POSITION_REGEX: RegExp = /(\d+-\d+)(?:,\s*)(\d+-\d+)/;
+export const POSITION_REGEX: RegExp = /(\d+-\d+)(?:\s*,\s*)(\d+-\d+)/;

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -134,3 +134,6 @@ export const VAR_OPEN_BRACKET: RegExp = /(=)?\s*[\[\{\(](|.*,)\s*$/;
 //     ...
 // ]  <- close bracket
 export const VAR_CLOSE_BRACKET: RegExp = /\s*[\]\}\)]\s*/;
+
+// position = 1-1, 2-2
+export const POSITION_REGEX: RegExp = /(\d+-\d+)(?:,\s*)(\d+-\d+)/;

--- a/src/relatedSettingsRules/index.ts
+++ b/src/relatedSettingsRules/index.ts
@@ -15,7 +15,7 @@ import forecastStartTime from "./valueValidation/forecastStartTime";
 import paletteTicks from "./valueValidation/paletteTicks";
 import startEndTime from "./valueValidation/startEndTime";
 import summarizePeriodTimespan from "./valueValidation/summarizePeriodTimespan";
-import widgetsOverlap from "./valueValidation/widgetsOverlap";
+import widgetsGridOverflow from "./valueValidation/widgetsGridOverflow";
 import widgetsPerRow from "./valueValidation/widgetsPerRow";
 
 const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
@@ -46,7 +46,7 @@ const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
     ],
     [
         "group", [
-            widgetsOverlap,
+            widgetsGridOverflow,
             widgetsPerRow
         ]
     ]

--- a/src/relatedSettingsRules/index.ts
+++ b/src/relatedSettingsRules/index.ts
@@ -2,6 +2,7 @@ import iconSettings from "./presenceValidation/iconSettings";
 import metricsAndEvaluateExpr from "./presenceValidation/metricsAndEvaluateExpr";
 import { noUselessSettingsForSeries, noUselessSettingsForWidget } from "./presenceValidation/noUselessSettings/index";
 import simultaneousTimeSettings from "./presenceValidation/noUselessSettings/simultaneousTimeSettings";
+import widgetsDimensions from "./presenceValidation/noUselessSettings/widgetsDimensions";
 import requiredSettings from "./presenceValidation/requiredSettings";
 import { Rule } from "./utils/interfaces";
 import calendarTimespan from "./valueValidation/calendarTimespan";
@@ -14,6 +15,7 @@ import forecastStartTime from "./valueValidation/forecastStartTime";
 import paletteTicks from "./valueValidation/paletteTicks";
 import startEndTime from "./valueValidation/startEndTime";
 import summarizePeriodTimespan from "./valueValidation/summarizePeriodTimespan";
+import widgetsOverlap from "./valueValidation/widgetsOverlap";
 import widgetsPerRow from "./valueValidation/widgetsPerRow";
 
 const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
@@ -38,11 +40,13 @@ const rulesBySection: Map<string, Rule[]> = new Map<string, Rule[]>([
             paletteTicks,
             simultaneousTimeSettings,
             startEndTime,
-            summarizePeriodTimespan
+            summarizePeriodTimespan,
+            widgetsDimensions
         ]
     ],
     [
         "group", [
+            widgetsOverlap,
             widgetsPerRow
         ]
     ]

--- a/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
+++ b/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
@@ -20,7 +20,7 @@ const rule: Rule = {
                 diagnostic.push(
                     createDiagnostic(
                         setting.textRange,
-                        `${setting.displayName} has no effect if position is specified`,
+                        `\`width-units\` has no effect if \`position\` is specified`,
                         DiagnosticSeverity.Warning
                     )
                 );

--- a/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
+++ b/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
@@ -5,7 +5,7 @@ import { createDiagnostic, getValueOfSetting } from "../../../util";
 import { Rule } from "../../utils/interfaces";
 
 const rule: Rule = {
-    name: "Width-units and height-units have effect only if position is not set",
+    name: "Width-units and height-units have no effect if position is set",
     check(section: Section): Diagnostic[] | void {
         const position = section.getSetting("position");
 

--- a/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
+++ b/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
@@ -1,7 +1,7 @@
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 import { Section } from "../../../configTree/section";
 import { Setting } from "../../../setting";
-import { createDiagnostic, getValueOfSetting } from "../../../util";
+import { createDiagnostic } from "../../../util";
 import { Rule } from "../../utils/interfaces";
 
 const rule: Rule = {

--- a/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
+++ b/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
@@ -1,0 +1,34 @@
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
+import { Section } from "../../../configTree/section";
+import { Setting } from "../../../setting";
+import { createDiagnostic, getValueOfSetting } from "../../../util";
+import { Rule } from "../../utils/interfaces";
+
+const rule: Rule = {
+    name: "Width-units and height-units have effect only if position is not set",
+    check(section: Section): Diagnostic[] | void {
+        const position = section.getSetting("position");
+
+        const foundSettings: Setting[] = ["widthunits", "heightunits"]
+            .map(settingName => section.getSetting(settingName))
+            .filter(element => element !== undefined);
+
+        const diagnostic: Diagnostic[] = [];
+
+        if (position) {
+            foundSettings.forEach(setting => {
+                diagnostic.push(
+                    createDiagnostic(
+                        setting.textRange,
+                        `${setting.displayName} has no effect is position is specified`,
+                        DiagnosticSeverity.Warning
+                    )
+                );
+            });
+        }
+
+        return diagnostic;
+    }
+};
+
+export default rule;

--- a/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
+++ b/src/relatedSettingsRules/presenceValidation/noUselessSettings/widgetsDimensions.ts
@@ -20,7 +20,7 @@ const rule: Rule = {
                 diagnostic.push(
                     createDiagnostic(
                         setting.textRange,
-                        `${setting.displayName} has no effect is position is specified`,
+                        `${setting.displayName} has no effect if position is specified`,
                         DiagnosticSeverity.Warning
                     )
                 );

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -33,11 +33,16 @@ const rule: Rule = {
  */
 function parsePosition(setting: Setting): Coordinates | null {
     let fullForm: string = setting.value;
+    const errorMessage: string = `Can't parse widget's ${setting.displayName}.`
+        + ` Correct setting syntax is, for example: '${setting.example}'`;
+
     /**
      * Process case for 'position = 1-1' shorthand and turn it into 'position = 1-1, 1-1'
      */
     if (setting.value.indexOf(",") < 0) {
         fullForm += "," + setting.value;
+    } else if (setting.value.split(",").length > 2) {
+        throw new Error(errorMessage);
     }
 
     const match = POSITION_REGEX.exec(fullForm);
@@ -53,8 +58,7 @@ function parsePosition(setting: Setting): Coordinates | null {
             y2: +end[0],
         };
     } catch (error) {
-        throw new Error(`Can't parse widget's ${setting.displayName}.`
-            + ` Correct setting syntax is, for example: '${setting.example}'`);
+        throw new Error(errorMessage);
     }
 }
 

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -52,7 +52,8 @@ const rule: Rule = {
                             if (grid[i] === undefined || grid[i][j] === undefined) {
                                 errors.push(createDiagnostic(
                                     position.textRange,
-                                    `Widget's position '${position.value}' overflows grid ${gridHeight}x${gridWidth}`,
+                                    `Widget \`position\` '${position.value}' overflows grid` +
+                                    ` ${gridHeight} times ${gridWidth}`,
                                     DiagnosticSeverity.Warning
                                 ));
                                 break outer;
@@ -107,7 +108,7 @@ function parsePosition(setting: Setting): Coordinates | null {
             y2: +end[0],
         };
     } catch (error) {
-        throw new Error(`Can't parse widget's position.`
+        throw new Error(`Can't parse widget's \`position\`.`
             + ` Correct setting syntax is, for example: '${setting.example}'`);
     }
 }

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -63,15 +63,16 @@ function parsePosition(setting: Setting): Coordinates | null {
  * @param widget - widget section to check
  */
 function detectGridOverflow(widget: Section): Diagnostic | void {
-    /**
-     * Get grid dimensions out of width- and height-units defined in configuration
-     * Or use default dimensions
-     */
-    const gridWidth = +getValueOfSetting("width-units", widget.parent.parent);
-    const gridHeight = +getValueOfSetting("height-units", widget.parent.parent);
     const position = widget.getSettingFromTree("position");
 
     if (position) {
+        /**
+         * Get grid dimensions out of width- and height-units defined in configuration
+         * Or use default dimensions
+         */
+        const gridWidth = +getValueOfSetting("width-units", widget.parent.parent);
+        const gridHeight = +getValueOfSetting("height-units", widget.parent.parent);
+
         try {
             const { x1, x2, y1, y2 } = parsePosition(position);
             if (x1 < 1 || x2 > gridWidth || y1 < 1 || y2 > gridHeight) {

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -52,7 +52,7 @@ const rule: Rule = {
                             if (grid[i] === undefined || grid[i][j] === undefined) {
                                 errors.push(createDiagnostic(
                                     position.textRange,
-                                    `Widget's position '${position.value}' overflows grid ${gridWidth}x${gridHeight}`,
+                                    `Widget's position '${position.value}' overflows grid ${gridHeight}x${gridWidth}`,
                                     DiagnosticSeverity.Warning
                                 ));
                                 break outer;

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -1,6 +1,7 @@
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
 import { Section } from "../../configTree/section";
 import { POSITION_REGEX } from "../../regExpressions";
+import { Setting } from "../../setting";
 import { createDiagnostic, getValueOfSetting } from "../../util";
 import { Rule } from "../utils/interfaces";
 
@@ -21,36 +22,24 @@ const rule: Rule = {
         const gridWidth = +getValueOfSetting("width-units", section.parent);
         const gridHeight = +getValueOfSetting("height-units", section.parent);
 
-        const grid = [];
-        const errors: Diagnostic[] = [];
-
-        /**
-         * Used to calcaulate X coordinate of last relative widget (position not specified)
-         */
-        let lastWidgetPosition = 0;
-
         /**
          * Create model grid to detect widgets intersection
          */
+        const grid = [];
         for (let i = 0; i < gridWidth; i++) {
             grid[i] = new Array(gridHeight).fill(0);
         }
 
+        const errors: Diagnostic[] = [];
         section.children.forEach(widget => {
-            const position = getValueOfSetting("position", widget, false);
-            /**
-             * Get own widget's height and width units if specified
-             * Otherwise pick default value
-             */
-            const width = +getValueOfSetting("width-units", widget, false);
-            const height = +getValueOfSetting("height-units", widget, false);
+            const position = widget.getSettingFromTree("position");
 
             /**
              * Position is specified try to parse it, check for syntax correctness
              */
             if (position) {
                 try {
-                    const { x1, x2, y1, y2 } = parsePosition(position.toString());
+                    const { x1, x2, y1, y2 } = parsePosition(position);
 
                     /**
                      * Position is 1-based, while array is 0-based
@@ -61,13 +50,11 @@ const rule: Rule = {
                              * We are out of grid defined in configuration
                              */
                             if (grid[i] === undefined || grid[i][j] === undefined) {
-                                errors.push(
-                                    createDiagnostic(
-                                        widget.range.range,
-                                        `Widget position '${position}' overflows grid ${gridWidth}x${gridHeight}`,
-                                        DiagnosticSeverity.Warning
-                                    )
-                                );
+                                errors.push(createDiagnostic(
+                                    position.textRange,
+                                    `Widget's position '${position.value}' overflows grid ${gridWidth}x${gridHeight}`,
+                                    DiagnosticSeverity.Warning
+                                ));
                                 break outer;
                             }
 
@@ -80,43 +67,10 @@ const rule: Rule = {
                      */
                     errors.push(
                         createDiagnostic(
-                            widget.getSettingFromTree("position").textRange,
+                            position.textRange,
                             e.message
                         )
                     );
-                }
-            } else {
-                /**
-                 * Position is not specified — we met a relatively positioned widget
-                 */
-                const x1 = lastWidgetPosition + 1;
-                const y1 = 1;
-                const x2 = x1 + width;
-                const y2 = y1 + height;
-                lastWidgetPosition = x2;
-
-                for (let i = x1 - 1; i < x2; i++) {
-                    for (let j = y1 - 1; j < y2; j++) {
-                        if (grid[i] === undefined || grid[i][j] === undefined) {
-                            /**
-                             * Relative positioned widgets grid overflow is validated separately in widgetsPerRow
-                             */
-                            continue;
-                        } else if (grid[i][j]) {
-                            /**
-                             * There is already widget at the position
-                             */
-                            errors.push(
-                                createDiagnostic(
-                                    widget.parent.range.range,
-                                    `Widgets overlap at ${i + 1}-${j + 1}`,
-                                    DiagnosticSeverity.Warning
-                                )
-                            );
-                        } else {
-                            grid[i][j] = 1;
-                        }
-                    }
                 }
             }
         });
@@ -131,13 +85,13 @@ const rule: Rule = {
  * Widget position parsing helper function
  * @param line — position setting
  */
-function parsePosition(line: string): Coordinates | null {
-    let fullForm: string = line;
+function parsePosition(setting: Setting): Coordinates | null {
+    let fullForm: string = setting.value;
     /**
      * Process case for 'position = 1-1' shorthand and turn it into 'position = 1-1, 1-1'
      */
-    if (line.split(",").length === 1) {
-        fullForm += "," + line;
+    if (setting.value.split(",").length === 1) {
+        fullForm += "," + setting.value;
     }
 
     const match = POSITION_REGEX.exec(fullForm);
@@ -154,7 +108,7 @@ function parsePosition(line: string): Coordinates | null {
         };
     } catch (error) {
         throw new Error(`Can't parse widget's position.`
-            + ` Position should be, for example: '1-1, 2-2' or '1-1' (= '1-1, 1-1' short form)`);
+            + ` Correct setting syntax is, for example: '${setting.example}'`);
     }
 }
 

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -29,14 +29,14 @@ const rule: Rule = {
 
 /**
  * Widget position parsing helper function
- * @param line — position setting
+ * @param setting — position setting
  */
 function parsePosition(setting: Setting): Coordinates | null {
     let fullForm: string = setting.value;
     /**
      * Process case for 'position = 1-1' shorthand and turn it into 'position = 1-1, 1-1'
      */
-    if (setting.value.split(",").length === 1) {
+    if (setting.value.indexOf(",") < 0) {
         fullForm += "," + setting.value;
     }
 
@@ -78,7 +78,7 @@ function detectGridOverflow(widget: Section): Diagnostic | void {
                 return createDiagnostic(
                     position.textRange,
                     `Widget ${position.displayName} '${position.value}' overflows grid` +
-                    ` ${gridHeight} times ${gridWidth}`,
+                    ` ${gridHeight} × ${gridWidth}`,
                     DiagnosticSeverity.Warning
                 );
             }

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -15,70 +15,15 @@ interface Coordinates {
 const rule: Rule = {
     name: "check that widgets per row don't overflow [group]",
     check(section: Section): Diagnostic[] | void {
-        /**
-         * Get grid dimensions out of width- and height-units defined in configuration
-         * Or use default dimensions
-         */
-        const gridWidth = +getValueOfSetting("width-units", section.parent);
-        const gridHeight = +getValueOfSetting("height-units", section.parent);
+        return section.children.reduce((total, widget) => {
+            const diagnostic = detectGridOverflow(widget);
 
-        /**
-         * Create model grid to detect widgets intersection
-         */
-        const grid = [];
-        for (let i = 0; i < gridWidth; i++) {
-            grid[i] = new Array(gridHeight).fill(0);
-        }
-
-        const errors: Diagnostic[] = [];
-        section.children.forEach(widget => {
-            const position = widget.getSettingFromTree("position");
-
-            /**
-             * Position is specified try to parse it, check for syntax correctness
-             */
-            if (position) {
-                try {
-                    const { x1, x2, y1, y2 } = parsePosition(position);
-
-                    /**
-                     * Position is 1-based, while array is 0-based
-                     */
-                    outer: for (let i = x1 - 1; i < x2; i++) {
-                        for (let j = y1 - 1; j < y2; j++) {
-                            /**
-                             * We are out of grid defined in configuration
-                             */
-                            if (grid[i] === undefined || grid[i][j] === undefined) {
-                                errors.push(createDiagnostic(
-                                    position.textRange,
-                                    `Widget \`position\` '${position.value}' overflows grid` +
-                                    ` ${gridHeight} times ${gridWidth}`,
-                                    DiagnosticSeverity.Warning
-                                ));
-                                break outer;
-                            }
-
-                            grid[i][j] = 1;
-                        }
-                    }
-                } catch (e) {
-                    /**
-                     * Process 'position' setting parse errors
-                     */
-                    errors.push(
-                        createDiagnostic(
-                            position.textRange,
-                            e.message
-                        )
-                    );
-                }
+            if (diagnostic) {
+                total.push(diagnostic);
             }
-        });
 
-        if (errors.length) {
-            return errors;
-        }
+            return total;
+        }, []);
     }
 };
 
@@ -110,6 +55,42 @@ function parsePosition(setting: Setting): Coordinates | null {
     } catch (error) {
         throw new Error(`Can't parse widget's \`position\`.`
             + ` Correct setting syntax is, for example: '${setting.example}'`);
+    }
+}
+
+/**
+ * Check if widget position doesn't overflow grid
+ * @param widget - widget section to check
+ */
+function detectGridOverflow(widget: Section): Diagnostic | void {
+    /**
+     * Get grid dimensions out of width- and height-units defined in configuration
+     * Or use default dimensions
+     */
+    const gridWidth = +getValueOfSetting("width-units", widget.parent.parent);
+    const gridHeight = +getValueOfSetting("height-units", widget.parent.parent);
+    const position = widget.getSettingFromTree("position");
+
+    if (position) {
+        try {
+            const { x1, x2, y1, y2 } = parsePosition(position);
+            if (x1 < 1 || x2 > gridWidth || y1 < 1 || y2 > gridHeight) {
+                return createDiagnostic(
+                    position.textRange,
+                    `Widget \`position\` '${position.value}' overflows grid` +
+                    ` ${gridHeight} times ${gridWidth}`,
+                    DiagnosticSeverity.Warning
+                );
+            }
+        } catch (e) {
+            /**
+             * Process 'position' setting parse errors
+             */
+            return createDiagnostic(
+                position.textRange,
+                e.message
+            );
+        }
     }
 }
 

--- a/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsGridOverflow.ts
@@ -15,75 +15,21 @@ interface Coordinates {
 const rule: Rule = {
     name: "check that widgets per row don't overflow [group]",
     check(section: Section): Diagnostic[] | void {
-        /**
-         * Get grid dimensions out of width- and height-units defined in configuration
-         * Or use default dimensions
-         */
-        const gridWidth = +getValueOfSetting("width-units", section.parent);
-        const gridHeight = +getValueOfSetting("height-units", section.parent);
+        return section.children.reduce((total, widget) => {
+            const diagnostic = detectGridOverflow(widget);
 
-        /**
-         * Create model grid to detect widgets intersection
-         */
-        const grid = [];
-        for (let i = 0; i < gridWidth; i++) {
-            grid[i] = new Array(gridHeight).fill(0);
-        }
-
-        const errors: Diagnostic[] = [];
-        section.children.forEach(widget => {
-            const position = widget.getSettingFromTree("position");
-
-            /**
-             * Position is specified try to parse it, check for syntax correctness
-             */
-            if (position) {
-                try {
-                    const { x1, x2, y1, y2 } = parsePosition(position);
-
-                    /**
-                     * Position is 1-based, while array is 0-based
-                     */
-                    for (let i = x1 - 1; i < x2; i++) {
-                        for (let j = y1 - 1; j < y2; j++) {
-                            /**
-                             * We are out of grid defined in configuration
-                             */
-                            if (grid[i] === undefined || grid[i][j] === undefined) {
-                                errors.push(createDiagnostic(
-                                    position.textRange,
-                                    `Widget ${position.displayName} '${position.value}' overflows grid` +
-                                    ` ${gridHeight} times ${gridWidth}`,
-                                    DiagnosticSeverity.Warning
-                                ));
-                            }
-
-                            grid[i][j] = 1;
-                        }
-                    }
-                } catch (e) {
-                    /**
-                     * Process 'position' setting parse errors
-                     */
-                    errors.push(
-                        createDiagnostic(
-                            position.textRange,
-                            e.message
-                        )
-                    );
-                }
+            if (diagnostic) {
+                total.push(diagnostic);
             }
-        });
 
-        if (errors.length) {
-            return errors;
-        }
+            return total;
+        }, []);
     }
 };
 
 /**
  * Widget position parsing helper function
- * @param setting {Setting} - position setting
+ * @param line — position setting
  */
 function parsePosition(setting: Setting): Coordinates | null {
     let fullForm: string = setting.value;
@@ -109,6 +55,42 @@ function parsePosition(setting: Setting): Coordinates | null {
     } catch (error) {
         throw new Error(`Can't parse widget's ${setting.displayName}.`
             + ` Correct setting syntax is, for example: '${setting.example}'`);
+    }
+}
+
+/**
+ * Check if widget position doesn't overflow grid
+ * @param widget - widget section to check
+ */
+function detectGridOverflow(widget: Section): Diagnostic | void {
+    /**
+     * Get grid dimensions out of width- and height-units defined in configuration
+     * Or use default dimensions
+     */
+    const gridWidth = +getValueOfSetting("width-units", widget.parent.parent);
+    const gridHeight = +getValueOfSetting("height-units", widget.parent.parent);
+    const position = widget.getSettingFromTree("position");
+
+    if (position) {
+        try {
+            const { x1, x2, y1, y2 } = parsePosition(position);
+            if (x1 < 1 || x2 > gridWidth || y1 < 1 || y2 > gridHeight) {
+                return createDiagnostic(
+                    position.textRange,
+                    `Widget ${position.displayName} '${position.value}' overflows grid` +
+                    ` ${gridHeight} times ${gridWidth}`,
+                    DiagnosticSeverity.Warning
+                );
+            }
+        } catch (e) {
+            /**
+             * Process 'position' setting parse errors
+             */
+            return createDiagnostic(
+                position.textRange,
+                e.message
+            );
+        }
     }
 }
 

--- a/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
@@ -34,11 +34,6 @@ const rule: Rule = {
             if (position) {
                 try {
                     let { x1, x2, y1, y2 } = parsePosition(position.toString());
-                    /**
-                     * We have 1-based rows & cells
-                     */
-                    x2 *= width;
-                    y2 *= height;
 
                     outer: for (let i = x1 - 1; i < x2; i++) {
                         for (let j = y1 - 1; j < y2; j++) {

--- a/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
@@ -84,8 +84,6 @@ const rule: Rule = {
             }
         });
 
-        // console.log("Filled grid", grid);
-
         if (errors.length) {
             return createDiagnostic(
                 section.range.range,

--- a/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
@@ -33,7 +33,7 @@ const rule: Rule = {
 
             if (position) {
                 try {
-                    let { x1, x2, y1, y2 } = parsePosition(position.toString());
+                    const { x1, x2, y1, y2 } = parsePosition(position.toString());
 
                     outer: for (let i = x1 - 1; i < x2; i++) {
                         for (let j = y1 - 1; j < y2; j++) {

--- a/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
@@ -1,0 +1,126 @@
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver-types";
+import { Section } from "../../configTree/section";
+import { POSITION_REGEX } from "../../regExpressions";
+import { createDiagnostic, getValueOfSetting } from "../../util";
+import { Rule } from "../utils/interfaces";
+
+interface Coordinates {
+    x1: number;
+    x2: number;
+    y1: number;
+    y2: number;
+}
+
+const rule: Rule = {
+    name: "check that widgets per row don't overflow [group]",
+    check(section: Section): Diagnostic | void {
+        const groupWidth = +getValueOfSetting("width-units", section.parent, false);
+        const groupHeight = +getValueOfSetting("height-units", section.parent, false);
+
+        const grid = [];
+        const errors: string[] = [];
+
+        let lastRelativeWidgetPosX = 1;
+
+        for (let i = 0; i < groupWidth; i++) {
+            grid[i] = new Array(groupHeight).fill(0);
+        }
+
+        section.children.forEach(widget => {
+            const position = getValueOfSetting("position", widget, false);
+            const width = +getValueOfSetting("width-units", widget, false);
+            const height = +getValueOfSetting("height-units", widget, false);
+
+            if (position) {
+                try {
+                    let { x1, x2, y1, y2 } = parsePosition(position.toString());
+                    /**
+                     * We have 1-based rows & cells
+                     */
+                    x2 *= width;
+                    y2 *= height;
+
+                    outer: for (let i = x1 - 1; i < x2; i++) {
+                        for (let j = y1 - 1; j < y2; j++) {
+                            if (grid[i] === undefined || grid[i][j] === undefined) {
+                                errors.push(
+                                    `Widget position '${position}' overflows grid ${groupWidth}x${groupHeight}`
+                                );
+                                break outer;
+                            }
+
+                            if (grid[i][j]) {
+                                errors.push(
+                                    `Widget with position '${position}' overlaps other widget at ${i + 1}-${j + 1}`
+                                );
+                                break outer;
+                            }
+
+                            grid[i][j] = 1;
+                        }
+                    }
+                } catch (e) {
+                    errors.push(e.message);
+                }
+            } else {
+                const x1 = lastRelativeWidgetPosX + 1;
+                const y1 = 1;
+                const x2 = x1 + width;
+                const y2 = y1 + height;
+                lastRelativeWidgetPosX = x2;
+
+                for (let i = x1 - 1; i < x2; i++) {
+                    for (let j = y1 - 1; j < y2; j++) {
+                        if (grid[i] === undefined || grid[i][j] === undefined) {
+                            /**
+                             * Relative positioned widgets grid overflow is validated separately in widgetsPerRow
+                             */
+                            continue;
+                        } else {
+                            grid[i][j] = 1;
+                        }
+                    }
+                }
+            }
+        });
+
+        // console.log("Filled grid", grid);
+
+        if (errors.length) {
+            return createDiagnostic(
+                section.range.range,
+                errors[0],
+                DiagnosticSeverity.Warning
+            );
+        }
+    }
+};
+
+function parsePosition(line: string): Coordinates | null {
+    let fullForm: string = line;
+    /**
+     * Process case for 'position = 1-1' shorthand and turn it into 'position = 1-1, 1-1'
+     */
+    if (line.split(",").length === 1) {
+        fullForm += "," + line;
+    }
+
+    const match = POSITION_REGEX.exec(fullForm);
+
+    try {
+        const start = match[1].split("-");
+        const end = match[2].split("-");
+
+        return {
+            x1: +start[1],
+            x2: +end[1],
+            y1: +start[0],
+            y2: +end[0],
+        };
+    } catch (error) {
+        throw new Error(`Can't parse widget's position.`
+            + ` '${line}' doesn't seem to match {number}-{number} schema`);
+    }
+}
+
+export default rule;

--- a/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
+++ b/src/relatedSettingsRules/valueValidation/widgetsOverlap.ts
@@ -14,13 +14,13 @@ interface Coordinates {
 const rule: Rule = {
     name: "check that widgets per row don't overflow [group]",
     check(section: Section): Diagnostic | void {
-        const groupWidth = +getValueOfSetting("width-units", section.parent, false);
-        const groupHeight = +getValueOfSetting("height-units", section.parent, false);
+        const groupWidth = +getValueOfSetting("width-units", section.parent);
+        const groupHeight = +getValueOfSetting("height-units", section.parent);
 
         const grid = [];
         const errors: string[] = [];
 
-        let lastRelativeWidgetPosX = 1;
+        let lastWidgetPosition = 0;
 
         for (let i = 0; i < groupWidth; i++) {
             grid[i] = new Array(groupHeight).fill(0);
@@ -44,13 +44,6 @@ const rule: Rule = {
                                 break outer;
                             }
 
-                            if (grid[i][j]) {
-                                errors.push(
-                                    `Widget with position '${position}' overlaps other widget at ${i + 1}-${j + 1}`
-                                );
-                                break outer;
-                            }
-
                             grid[i][j] = 1;
                         }
                     }
@@ -58,11 +51,11 @@ const rule: Rule = {
                     errors.push(e.message);
                 }
             } else {
-                const x1 = lastRelativeWidgetPosX + 1;
+                const x1 = lastWidgetPosition + 1;
                 const y1 = 1;
                 const x2 = x1 + width;
                 const y2 = y1 + height;
-                lastRelativeWidgetPosX = x2;
+                lastWidgetPosition = x2;
 
                 for (let i = x1 - 1; i < x2; i++) {
                     for (let j = y1 - 1; j < y2; j++) {
@@ -71,6 +64,10 @@ const rule: Rule = {
                              * Relative positioned widgets grid overflow is validated separately in widgetsPerRow
                              */
                             continue;
+                        } else if (grid[i][j]) {
+                            errors.push(
+                                `Widgets overlap at ${i + 1}-${j + 1}`
+                            );
                         } else {
                             grid[i][j] = 1;
                         }

--- a/src/resources/descriptions.md
+++ b/src/resources/descriptions.md
@@ -1221,7 +1221,7 @@ Define the location of the final value pointer.
   
 ## position  
   
-Position of the column relative to other columns in the table.  
+Defines cells on the grid where widget will be located.  
   
 ## primarykey  
   

--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -5589,9 +5589,9 @@
         },
         {
             "displayName": "position",
-            "section": "column",
+            "section": "widget",
             "type": "string",
-            "example": "first"
+            "example": "1-1, 2-2"
         },
         {
             "displayName": "primary-key",

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -19,9 +19,10 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(1, 5, 1),
-                "Can't parse widget's position. '0' doesn't seem to match {number}-{number} schema",
-                DiagnosticSeverity.Warning
+                createRange(4, 8, 4),
+                "Can't parse widget's position." +
+                " Position should be, for example: '1-1, 2-2' or '1-1' (= '1-1, 1-1' short form)",
+                DiagnosticSeverity.Error
             )
         ];
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
@@ -41,7 +42,7 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(1, 5, 1),
+                createRange(3, 6, 2),
                 "Widget position '10-10, 11-11' overflows grid 6x4",
                 DiagnosticSeverity.Warning
             )

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -3,7 +3,8 @@ import { DiagnosticSeverity } from "vscode-languageserver-types";
 import { createDiagnostic, createRange } from "../util";
 import { Validator } from "../validator";
 
-const baseConfig = (setting: string) => `[configuration]
+const baseConfig = (setting: string, dimensions: string = "") => `[configuration]
+${dimensions}
 [group]
   [widget]
     type = chart
@@ -19,7 +20,7 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(4, 8, 4),
+                createRange(4, 8, 5),
                 "Can't parse widget's position. Correct setting syntax is, for example: '1-1, 2-2'",
                 DiagnosticSeverity.Error
             )
@@ -49,8 +50,8 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(4, 8, 4),
-                "Widget position '0-0' overflows grid 4 × 6",
+                createRange(4, 8, 5),
+                "Widget position '0-0' overflows grid 4×6",
                 DiagnosticSeverity.Warning
             )
         ];
@@ -63,7 +64,7 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(4, 8, 4),
+                createRange(4, 8, 5),
                 "Can't parse widget's position. Correct setting syntax is, for example: '1-1, 2-2'"
             )
         ];
@@ -78,14 +79,32 @@ suite("Widgets position tests", () => {
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
     });
 
+    test("Widget's position overflows grid with invalid dimensions (use default ones)", () => {
+        const config = baseConfig("position = 10-10, 11-11", "width-units = 'hello world'\n");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(0, 11, 1),
+                "width-units should be a real (floating-point) number. For example, 2"
+            ),
+            createDiagnostic(
+                createRange(4, 8, 6),
+                "Widget position '10-10, 11-11' overflows grid 4×6",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
     test("Widget's position overflows grid 10x10", () => {
         const config = baseConfig("position = 10-10, 11-11");
         const validator = new Validator(config);
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(4, 8, 4),
-                "Widget position '10-10, 11-11' overflows grid 4 × 6",
+                createRange(4, 8, 5),
+                "Widget position '10-10, 11-11' overflows grid 4×6",
                 DiagnosticSeverity.Warning
             )
         ];
@@ -98,8 +117,8 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(4, 8, 4),
-                "Widget position '11-11' overflows grid 4 × 6",
+                createRange(4, 8, 5),
+                "Widget position '11-11' overflows grid 4×6",
                 DiagnosticSeverity.Warning
             )
         ];
@@ -112,7 +131,7 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(2, 11, 5),
+                createRange(2, 11, 6),
                 "'width-units' has no effect if 'position' is specified",
                 DiagnosticSeverity.Warning
             )

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -4,8 +4,6 @@ import { createDiagnostic, createRange } from "../util";
 import { Validator } from "../validator";
 
 const baseConfig = (setting: string) => `[configuration]
-width-units = 10
-height-units = 10
 [group]
   [widget]
     type = chart
@@ -21,7 +19,7 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(1, 5, 3),
+                createRange(1, 5, 1),
                 "Can't parse widget's position. '0' doesn't seem to match {number}-{number} schema",
                 DiagnosticSeverity.Warning
             )
@@ -43,8 +41,8 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(1, 5, 3),
-                "Widget position '10-10, 11-11' overflows grid 10x10",
+                createRange(1, 5, 1),
+                "Widget position '10-10, 11-11' overflows grid 6x4",
                 DiagnosticSeverity.Warning
             )
         ];
@@ -57,7 +55,7 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(2, 11, 7),
+                createRange(2, 11, 5),
                 "width-units has no effect is position is specified",
                 DiagnosticSeverity.Warning
             )
@@ -65,13 +63,8 @@ suite("Widgets position tests", () => {
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
     });
 
-    /**
-     * Skip for now because not sure how absolute and relative widgets should be positioned
-     */
-    test.skip("Absolute and relative widgets overlap each other", () => {
+    test("Absolute and relative widgets overlap each other", () => {
         const config = `[configuration]
-        width-units = 10
-        height-units = 10
     [group]
       [widget]
           type = chart
@@ -89,8 +82,8 @@ suite("Widgets position tests", () => {
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(1, 5, 3),
-                "Widget position '10-10, 11-11' overflows grid 10x10",
+                createRange(5, 5, 1),
+                "Widgets overlap at 1-1",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -56,7 +56,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(2, 11, 5),
-                "width-units has no effect is position is specified",
+                "width-units has no effect if position is specified",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -43,6 +43,41 @@ suite("Widgets position tests", () => {
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
     });
 
+    test("Incorrect zero widgets position", () => {
+        const config = baseConfig("position = 0-0");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 8, 4),
+                "Widget position '0-0' overflows grid 4 × 6",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Incorrect negative widgets position", () => {
+        const config = baseConfig("position = -1-0");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 8, 4),
+                "Can't parse widget's position. Correct setting syntax is, for example: '1-1, 2-2'"
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Correct widgets position, space before comma", () => {
+        const config = baseConfig("position = 1-1 , 2-2");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
     test("Widget's position overflows grid 10x10", () => {
         const config = baseConfig("position = 10-10, 11-11");
         const validator = new Validator(config);

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -1,0 +1,99 @@
+import { deepStrictEqual } from "assert";
+import { DiagnosticSeverity } from "vscode-languageserver-types";
+import { createDiagnostic, createRange } from "../util";
+import { Validator } from "../validator";
+
+const baseConfig = (setting: string) => `[configuration]
+width-units = 10
+height-units = 10
+[group]
+  [widget]
+    type = chart
+    ${setting}
+    [series]
+      metric = a
+      entity = b`;
+
+suite("Widgets position tests", () => {
+    test("Incorrect widgets position", () => {
+        const config = baseConfig("position = 0");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(1, 5, 3),
+                "Can't parse widget's position. '0' doesn't seem to match {number}-{number} schema",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Correct widgets position", () => {
+        const config = baseConfig("position = 1-1, 2-2");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Widgets position overflows grid 10x10", () => {
+        const config = baseConfig("position = 10-10, 11-11");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(1, 5, 3),
+                "Widget position '10-10, 11-11' overflows grid 10x10",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Useless width-units with specified position", () => {
+        const config = baseConfig("position = 2-2, 3-3\n  width-units = 2");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(2, 11, 7),
+                "width-units has no effect is position is specified",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    /**
+     * Skip for now because not sure how absolute and relative widgets should be positioned
+     */
+    test.skip("Absolute and relative widgets overlap each other", () => {
+        const config = `[configuration]
+        width-units = 10
+        height-units = 10
+    [group]
+      [widget]
+          type = chart
+          position = 1-1, 2-2
+          [series]
+              metric = a
+              entity = b
+      [widget]
+          type = chart
+          [series]
+              metric = a
+              entity = b
+    `;
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(1, 5, 3),
+                "Widget position '10-10, 11-11' overflows grid 10x10",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+});

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -44,6 +44,19 @@ suite("Widgets position tests", () => {
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
     });
 
+    test("Incorrect widgets position (3 values)", () => {
+        const config = baseConfig("position = 1-1, 2-2, 3-3");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 8, 5),
+                "Can't parse widget's position. Correct setting syntax is, for example: '1-1, 2-2'"
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
     test("Incorrect zero widgets position", () => {
         const config = baseConfig("position = 0-0");
         const validator = new Validator(config);

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -42,7 +42,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 8, 4),
-                "Widget position '10-10, 11-11' overflows grid 4 times 6",
+                "Widget position '10-10, 11-11' overflows grid 4 × 6",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -20,8 +20,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 8, 4),
-                "Can't parse widget's position." +
-                " Position should be, for example: '1-1, 2-2' or '1-1' (= '1-1, 1-1' short form)",
+                "Can't parse widget's position. Correct setting syntax is, for example: '1-1, 2-2'",
                 DiagnosticSeverity.Error
             )
         ];
@@ -36,14 +35,14 @@ suite("Widgets position tests", () => {
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
     });
 
-    test("Widgets position overflows grid 10x10", () => {
+    test("Widget's position overflows grid 10x10", () => {
         const config = baseConfig("position = 10-10, 11-11");
         const validator = new Validator(config);
         const actualDiagnostic = validator.lineByLine();
         const expectedDiagnostic = [
             createDiagnostic(
-                createRange(3, 6, 2),
-                "Widget position '10-10, 11-11' overflows grid 6x4",
+                createRange(4, 8, 4),
+                "Widget's position '10-10, 11-11' overflows grid 6x4",
                 DiagnosticSeverity.Warning
             )
         ];
@@ -58,33 +57,6 @@ suite("Widgets position tests", () => {
             createDiagnostic(
                 createRange(2, 11, 5),
                 "width-units has no effect is position is specified",
-                DiagnosticSeverity.Warning
-            )
-        ];
-        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
-    });
-
-    test("Absolute and relative widgets overlap each other", () => {
-        const config = `[configuration]
-    [group]
-      [widget]
-          type = chart
-          position = 1-1, 2-2
-          [series]
-              metric = a
-              entity = b
-      [widget]
-          type = chart
-          [series]
-              metric = a
-              entity = b
-    `;
-        const validator = new Validator(config);
-        const actualDiagnostic = validator.lineByLine();
-        const expectedDiagnostic = [
-            createDiagnostic(
-                createRange(5, 5, 1),
-                "Widgets overlap at 1-1",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -20,7 +20,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 8, 4),
-                "Can't parse widget's position. Correct setting syntax is, for example: '1-1, 2-2'",
+                "Can't parse widget's `position`. Correct setting syntax is, for example: '1-1, 2-2'",
                 DiagnosticSeverity.Error
             )
         ];
@@ -42,7 +42,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 8, 4),
-                "Widget's position '10-10, 11-11' overflows grid 4x6",
+                "Widget \`position\` '10-10, 11-11' overflows grid 4 times 6",
                 DiagnosticSeverity.Warning
             )
         ];
@@ -56,7 +56,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(2, 11, 5),
-                "width-units has no effect if position is specified",
+                "`width-units` has no effect if `position` is specified",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -35,6 +35,14 @@ suite("Widgets position tests", () => {
         deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
     });
 
+    test("Correct widgets position shorthand", () => {
+        const config = baseConfig("position = 3-3");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
     test("Widget's position overflows grid 10x10", () => {
         const config = baseConfig("position = 10-10, 11-11");
         const validator = new Validator(config);
@@ -43,6 +51,20 @@ suite("Widgets position tests", () => {
             createDiagnostic(
                 createRange(4, 8, 4),
                 "Widget position '10-10, 11-11' overflows grid 4 × 6",
+                DiagnosticSeverity.Warning
+            )
+        ];
+        deepStrictEqual(actualDiagnostic, expectedDiagnostic, `Config: \n${config}`);
+    });
+
+    test("Widget's position (shorthand) overflows grid 10x10", () => {
+        const config = baseConfig("position = 11-11");
+        const validator = new Validator(config);
+        const actualDiagnostic = validator.lineByLine();
+        const expectedDiagnostic = [
+            createDiagnostic(
+                createRange(4, 8, 4),
+                "Widget position '11-11' overflows grid 4 × 6",
                 DiagnosticSeverity.Warning
             )
         ];

--- a/src/test/widgetsPosition.test.ts
+++ b/src/test/widgetsPosition.test.ts
@@ -42,7 +42,7 @@ suite("Widgets position tests", () => {
         const expectedDiagnostic = [
             createDiagnostic(
                 createRange(4, 8, 4),
-                "Widget's position '10-10, 11-11' overflows grid 6x4",
+                "Widget's position '10-10, 11-11' overflows grid 4x6",
                 DiagnosticSeverity.Warning
             )
         ];


### PR DESCRIPTION
Added widgets position validation rules:
* Warn if widgets position is out of the grid
* For absolutely positioned widget `width-units` and `height-units` have no effect 

**Config:**
```
[configuration]
  width-units = 10
  height-units = 10

[group]

  [widget]
    type = chart
    position = 11-11
    width-units = 4
    height-units = 3

    [series]
      metric = a
      entity = b

  [widget]
    type = chart

    [series]
      metric = a
      entity = b
```

**Interface:**
Position out of grid warning ⤵️
![image](https://user-images.githubusercontent.com/15448200/67282604-d67bdb80-f4da-11e9-90e9-746da431536b.png)


Width-units and height-units (similar) warnings if position is set ⤵️
![image](https://user-images.githubusercontent.com/15448200/67282273-0f678080-f4da-11e9-9c18-8716cac7becc.png)

