### PR TITLE
Remove auto-complete from JavaScript and control settings

### DIFF
--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -35,15 +35,15 @@ export class CompletionProvider {
      * Creates completion items
      */
     public getCompletionItems(): CompletionItem[] {
-        const valueMatch = /^\s*(\S+)\s*=\s*/.exec(this.currentLine);
-        const bracketsMatch = /\s*(\[.*?)\s*/.exec(this.currentLine);
-
         /**
          * No settings in IntelliSense suggestions (same line) for control keywords
          */
         if (KEYWORDS_REGEX.test(this.currentLine)) {
             return [];
         }
+
+        const valueMatch = /^\s*(\S+)\s*=\s*/.exec(this.currentLine);
+        const bracketsMatch = /\s*(\[.*?)\s*/.exec(this.currentLine);
 
         if (valueMatch) {
             // completion requested at assign stage, i. e. type = <Ctrl + space>

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -4,7 +4,7 @@ import {
 import { CALENDAR_KEYWORDS, CONTROL_KEYWORDS, INTERVAL_UNITS } from "./constants";
 import { Field } from "./field";
 import { LanguageService } from "./languageService";
-import { KEYWORDS_REGEX } from "./regExpressions";
+import { KEYWORDS_REGEX, OPENING_BRACKET, VALUE_MATCH, WORD_START } from "./regExpressions";
 import { ResourcesProviderBase } from "./resourcesProviderBase";
 import { Setting } from "./setting";
 import { deleteComments, deleteScripts, getSetting } from "./util";
@@ -42,8 +42,12 @@ export class CompletionProvider {
             return [];
         }
 
-        const valueMatch = /^\s*(\S+)\s*=\s*/.exec(this.currentLine);
-        const bracketsMatch = /\s*(\[.*?)\s*/.exec(this.currentLine);
+        const valueMatch = VALUE_MATCH.exec(this.currentLine);
+        const bracketsMatch = OPENING_BRACKET.exec(this.currentLine);
+        /**
+         * We are at the very beginning of a word
+         */
+        const wordStart = WORD_START.exec(this.currentLine);
 
         if (valueMatch) {
             // completion requested at assign stage, i. e. type = <Ctrl + space>
@@ -51,17 +55,18 @@ export class CompletionProvider {
         } else if (bracketsMatch) {
             // requested completion for section name in []
             return this.completeSectionName();
-        } else {
+        } else if (wordStart) {
             // completion requested at start of line (supposed that line is empty)
             return this.completeSnippets().concat(
                 this.completeIf(),
                 this.completeFor(),
                 this.completeSettingName(),
-                this.completeSectionName(),
                 this.completeControlKeyWord(),
-                this.completeEndKeyword()
+                this.completeEndKeyword(),
             );
         }
+
+        return [];
     }
 
     /**

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -62,7 +62,7 @@ export class CompletionProvider {
                 this.completeFor(),
                 this.completeSettingName(),
                 this.completeControlKeyWord(),
-                this.completeEndKeyword(),
+                this.completeEndKeyword()
             );
         }
 

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -4,6 +4,7 @@ import {
 import { CALENDAR_KEYWORDS, CONTROL_KEYWORDS, INTERVAL_UNITS } from "./constants";
 import { Field } from "./field";
 import { LanguageService } from "./languageService";
+import { KEYWORDS_REGEX } from "./regExpressions";
 import { ResourcesProviderBase } from "./resourcesProviderBase";
 import { Setting } from "./setting";
 import { deleteComments, deleteScripts, getSetting } from "./util";
@@ -36,6 +37,14 @@ export class CompletionProvider {
     public getCompletionItems(): CompletionItem[] {
         const valueMatch = /^\s*(\S+)\s*=\s*/.exec(this.currentLine);
         const bracketsMatch = /\s*(\[.*?)\s*/.exec(this.currentLine);
+
+        /**
+         * No settings in IntelliSense suggestions (same line) for control keywords
+         */
+        if (KEYWORDS_REGEX.test(this.currentLine)) {
+            return [];
+        }
+
         if (valueMatch) {
             // completion requested at assign stage, i. e. type = <Ctrl + space>
             return this.completeSettingValue(valueMatch[1]);
@@ -119,7 +128,7 @@ endfor`;
         // detected `end`
         const endWordRegex: RegExp = /^[ \t]*(end)[ \t]*/gm;
         // detected any control keyword in previous code
-        const keywordsRegex: RegExp = new RegExp(`^[ \t]*(?:${CONTROL_KEYWORDS.join("|")})[ \t]*`, "mg");
+        const keywordsRegex: RegExp = new RegExp(KEYWORDS_REGEX.source, KEYWORDS_REGEX.flags + "m");
         let completions: CompletionItem[] = [];
 
         if (endWordRegex.test(this.text)) {

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -43,19 +43,21 @@ export class CompletionProvider {
         }
 
         const valueMatch = VALUE_MATCH.exec(this.currentLine);
+        if (valueMatch) {
+            // completion requested at assign stage, i. e. type = <Ctrl + space>
+            return this.completeSettingValue(valueMatch[1]);
+        }
+
         const bracketsMatch = OPENING_BRACKET.exec(this.currentLine);
+        if (bracketsMatch) {
+            // requested completion for section name in []
+            return this.completeSectionName();
+        }
         /**
          * We are at the very beginning of a word
          */
         const wordStart = WORD_START.exec(this.currentLine);
-
-        if (valueMatch) {
-            // completion requested at assign stage, i. e. type = <Ctrl + space>
-            return this.completeSettingValue(valueMatch[1]);
-        } else if (bracketsMatch) {
-            // requested completion for section name in []
-            return this.completeSectionName();
-        } else if (wordStart) {
+        if (wordStart) {
             // completion requested at start of line (supposed that line is empty)
             return this.completeSnippets().concat(
                 this.completeIf(),

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -140,3 +140,13 @@ export const KEYWORDS_REGEX: RegExp = new RegExp(`^[ \t]*(?:${CONTROL_KEYWORDS.j
 
 // position = 1-1, 2-2
 export const POSITION_REGEX: RegExp = /(\d+-\d+)(?:\s*,\s*)(\d+-\d+)/;
+
+// [section -> true
+// [section] -> false
+export const OPENING_BRACKET: RegExp = /\[[^\]]*$/;
+
+// Some alpha characters at the beginnig of the line
+export const WORD_START: RegExp = /^\s*(\w)*\s*$/;
+
+// Matches setting value after '=' sign
+export const VALUE_MATCH: RegExp = /^\s*(\S+)\s*=\s*/;

--- a/src/regExpressions.ts
+++ b/src/regExpressions.ts
@@ -134,3 +134,6 @@ export const VAR_OPEN_BRACKET: RegExp = /(=)?\s*[\[\{\(](|.*,)\s*$/;
 //     ...
 // ]  <- close bracket
 export const VAR_CLOSE_BRACKET: RegExp = /\s*[\]\}\)]\s*/;
+
+// sql|script|if|for|var|list|csv|expr
+export const KEYWORDS_REGEX: RegExp = new RegExp(`^[ \t]*(?:${CONTROL_KEYWORDS.join("|")})[ \t]*`, "g");

--- a/src/test/completionProvider.test.ts
+++ b/src/test/completionProvider.test.ts
@@ -1,5 +1,5 @@
-import { strictEqual } from "assert";
-import { Position, TextDocument } from "vscode-languageserver-types";
+import { deepStrictEqual, strictEqual } from "assert";
+import { CompletionItem, Position, TextDocument } from "vscode-languageserver-types";
 import { CompletionProvider } from "../completionProvider";
 import { Test } from "./test";
 
@@ -62,5 +62,14 @@ suite("CompletionProvider endkeywords tests", () => {
         const cp: CompletionProvider = new CompletionProvider(document, position);
         const current: string[] = cp.getCompletionItems().map(i => i.insertText);
         strictEqual(current.includes(expected), false);
+    });
+
+    test("No IntelliSense suggestions (same line) for control keywords", () => {
+        const text = `csv =`;
+        const position = Position.create(2, 1);
+        const document: TextDocument = TextDocument.create("test", "axibasecharts", 1, text);
+        const cp: CompletionProvider = new CompletionProvider(document, position);
+        const current: CompletionItem[] = cp.getCompletionItems();
+        deepStrictEqual(current.length, 0);
     });
 });

--- a/src/test/completionProvider.test.ts
+++ b/src/test/completionProvider.test.ts
@@ -64,8 +64,26 @@ suite("CompletionProvider endkeywords tests", () => {
         strictEqual(current.includes(expected), false);
     });
 
-    test("No IntelliSense suggestions (same line) for control keywords", () => {
+    test("No suggestions (same line) for control keywords", () => {
         const text = `csv =`;
+        const position = Position.create(2, 1);
+        const document: TextDocument = TextDocument.create("test", "axibasecharts", 1, text);
+        const cp: CompletionProvider = new CompletionProvider(document, position);
+        const current: CompletionItem[] = cp.getCompletionItems();
+        deepStrictEqual(current.length, 0);
+    });
+
+    test("No section name suggestions if line already contains section", () => {
+        const text = `[widget] `;
+        const position = Position.create(2, 1);
+        const document: TextDocument = TextDocument.create("test", "axibasecharts", 1, text);
+        const cp: CompletionProvider = new CompletionProvider(document, position);
+        const current: CompletionItem[] = cp.getCompletionItems();
+        deepStrictEqual(current.length, 0);
+    });
+
+    test("No suggestions after if expression", () => {
+        const text = `if hello == 'abc' `;
         const position = Position.create(2, 1);
         const document: TextDocument = TextDocument.create("test", "axibasecharts", 1, text);
         const cp: CompletionProvider = new CompletionProvider(document, position);


### PR DESCRIPTION
Closes #95 and #98 

Completion Provider improvements:

- No suggestions for JavaScript completions and control (`sql|script|if|for|var|list|csv|expr`) settings
- No autocomplete fire if line is not empty (contains characters different from alpha ones: such as spaces, brackets, `=|>|<|?|~|!` etc)
- No section name suggestion if line already contains section (`[widget] >>` won't fire section suggestion, because `]` is present)