### PR TITLE
Add OHLC statistics to completion

### DIFF
--- a/src/resources/dictionary.json
+++ b/src/resources/dictionary.json
@@ -7623,6 +7623,11 @@
                 "threshold_count",
                 "threshold_duration",
                 "threshold_percent",
+                "open",
+                "high",
+                "low",
+                "close",
+                "vwap",
                 "ohlcv"
             ]
         },
@@ -7652,6 +7657,11 @@
                 "threshold_count",
                 "threshold_duration",
                 "threshold_percent",
+                "open",
+                "high",
+                "low",
+                "close",
+                "vwap",
                 "ohlcv"
             ]
         },


### PR DESCRIPTION
Add `open`, `close`, `high`, `low`, and `vwap` to statistics setting value set